### PR TITLE
Make per-user kernel pod resources configurable via Helm

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -88,6 +88,10 @@ func main() {
 		MaxKernels:        cfg.KernelPodMaxTotal,
 		PullSecret:        cfg.KernelPullSecret,
 		CredsResolver:     credsResolver,
+		PodCPURequest:     cfg.KernelPodCPURequest,
+		PodMemoryRequest:  cfg.KernelPodMemoryRequest,
+		PodCPULimit:       cfg.KernelPodCPULimit,
+		PodMemoryLimit:    cfg.KernelPodMemoryLimit,
 	})
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to initialize kernel gateway")

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -56,6 +56,14 @@ type Config struct {
 	KernelDockerNetwork   string
 	KernelPullSecret      string // optional K8s imagePullSecret for private forks
 
+	// Per-user kernel pod resource requests/limits. Strings in k8s quantity
+	// format ("500m", "1Gi"). For docker_per_user mode only the *Limit values
+	// apply — Docker has no separate "request" concept.
+	KernelPodCPURequest    string
+	KernelPodMemoryRequest string
+	KernelPodCPULimit      string
+	KernelPodMemoryLimit   string
+
 	// CORS
 	CORSOrigins []string
 }
@@ -99,6 +107,11 @@ func Load() *Config {
 		KernelPodMaxTotal:    getEnvInt("KERNEL_POD_MAX_TOTAL", 50),
 		KernelDockerNetwork:  getEnv("KERNEL_DOCKER_NETWORK", "sparklabx_default"),
 		KernelPullSecret:     getEnv("KERNEL_PULL_SECRET", ""), // empty → no imagePullSecret
+
+		KernelPodCPURequest:    getEnv("KERNEL_POD_CPU_REQUEST", "500m"),
+		KernelPodMemoryRequest: getEnv("KERNEL_POD_MEMORY_REQUEST", "1Gi"),
+		KernelPodCPULimit:      getEnv("KERNEL_POD_CPU_LIMIT", "2000m"),
+		KernelPodMemoryLimit:   getEnv("KERNEL_POD_MEMORY_LIMIT", "4Gi"),
 
 		CORSOrigins: strings.Split(getEnv("CORS_ORIGINS", "http://localhost:3000"), ","),
 	}

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/sparklabx/sparklabx/backend/internal/database"
 )
@@ -42,6 +43,17 @@ type DockerPerUserConfig struct {
 	MaxContainers int               // hard cap; rejects spawn beyond
 	MinIOEndpoint string            // injected as S3_ENDPOINT env so kernel reaches MinIO
 	CredsResolver UserCredsResolver // nil → fall back to root creds via env passthrough
+
+	// Per-container limits in k8s quantity format ("500m", "1Gi"). Docker
+	// doesn't have a separate "request" concept, so only the limit values
+	// apply. Empty → no limit (container can use all host resources).
+	CPULimit    string
+	MemoryLimit string
+
+	// Resolved at construction: CPULimit converted to nano-CPUs, MemoryLimit
+	// to bytes. Kept here so Spawn doesn't reparse on every container create.
+	nanoCPUs    int64
+	memoryBytes int64
 }
 
 func NewDockerPerUserGateway(cfg DockerPerUserConfig) (*DockerPerUserGateway, error) {
@@ -60,6 +72,21 @@ func NewDockerPerUserGateway(cfg DockerPerUserConfig) (*DockerPerUserGateway, er
 	}
 	if cfg.IdleTimeout == 0 {
 		cfg.IdleTimeout = 30 * time.Minute
+	}
+	if cfg.CPULimit != "" {
+		q, err := resource.ParseQuantity(cfg.CPULimit)
+		if err != nil {
+			return nil, fmt.Errorf("DockerPerUserConfig.CPULimit %q: %w", cfg.CPULimit, err)
+		}
+		// k8s quantity "2000m" → 2000 milli → 2_000_000_000 nano-CPUs
+		cfg.nanoCPUs = q.MilliValue() * 1_000_000
+	}
+	if cfg.MemoryLimit != "" {
+		q, err := resource.ParseQuantity(cfg.MemoryLimit)
+		if err != nil {
+			return nil, fmt.Errorf("DockerPerUserConfig.MemoryLimit %q: %w", cfg.MemoryLimit, err)
+		}
+		cfg.memoryBytes = q.Value()
 	}
 
 	transport := &http.Transport{
@@ -89,6 +116,24 @@ func (g *DockerPerUserGateway) IdleTimeout() time.Duration    { return g.cfg.Idl
 func dockerContainerName(userID string) string {
 	h := sha1.Sum([]byte(userID))
 	return "sparklabx-kernel-" + hex.EncodeToString(h[:6])
+}
+
+// hostConfig builds the Docker HostConfig fragment. Resource limits are
+// only attached when the operator opted in via CPULimit/MemoryLimit — a
+// zero value means "no limit" so existing deployments keep working.
+func hostConfig(cfg DockerPerUserConfig) map[string]any {
+	hc := map[string]any{
+		"RestartPolicy": map[string]any{"Name": "no"},
+		"NetworkMode":   cfg.Network,
+		"AutoRemove":    false,
+	}
+	if cfg.nanoCPUs > 0 {
+		hc["NanoCpus"] = cfg.nanoCPUs
+	}
+	if cfg.memoryBytes > 0 {
+		hc["Memory"] = cfg.memoryBytes
+	}
+	return hc
 }
 
 // Status returns current spawn phase from the DB row.
@@ -228,11 +273,7 @@ func (g *DockerPerUserGateway) EnsureSpawning(userID string) error {
 			"sparklabx.user":   userID,
 		},
 		"ExposedPorts": map[string]any{"8888/tcp": map[string]any{}},
-		"HostConfig": map[string]any{
-			"RestartPolicy": map[string]any{"Name": "no"},
-			"NetworkMode":   g.cfg.Network,
-			"AutoRemove":    false,
-		},
+		"HostConfig": hostConfig(g.cfg),
 	}
 	if err := g.containerCreate(ctx, name, cfg); err != nil {
 		g.updatePhase(userID, PhaseFailed, err.Error())

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -61,6 +61,14 @@ type K8sPerUserConfig struct {
 	MaxPods       int               // hard cap on concurrent pods cluster-wide
 	PullSecret    string            // optional imagePullSecret name; empty → none
 	CredsResolver UserCredsResolver // nil → use root creds from sparklabx-secrets (legacy)
+
+	// Per-pod resource quantities ("500m", "1Gi"). Empty → fall back to
+	// defaults (500m/1Gi requests, 2000m/4Gi limits). MustParse'd at spawn,
+	// so invalid values panic loudly instead of silently spawning misconfigured pods.
+	CPURequest    string
+	MemoryRequest string
+	CPULimit      string
+	MemoryLimit   string
 }
 
 // PodStatus is the spawn progress snapshot returned to FE for live UI updates.
@@ -97,6 +105,30 @@ func NewK8sPerUserGateway(cfg K8sPerUserConfig) (*K8sPerUserGateway, error) {
 	}
 	if cfg.Namespace == "" {
 		return nil, fmt.Errorf("K8sPerUserConfig.Namespace is required (set KERNEL_POD_NAMESPACE)")
+	}
+	if cfg.CPURequest == "" {
+		cfg.CPURequest = "500m"
+	}
+	if cfg.MemoryRequest == "" {
+		cfg.MemoryRequest = "1Gi"
+	}
+	if cfg.CPULimit == "" {
+		cfg.CPULimit = "2000m"
+	}
+	if cfg.MemoryLimit == "" {
+		cfg.MemoryLimit = "4Gi"
+	}
+	// Validate each quantity at construction time — better to fail at boot
+	// than have every Spawn panic with a less-readable trace.
+	for name, q := range map[string]string{
+		"CPURequest":    cfg.CPURequest,
+		"MemoryRequest": cfg.MemoryRequest,
+		"CPULimit":      cfg.CPULimit,
+		"MemoryLimit":   cfg.MemoryLimit,
+	} {
+		if _, err := resource.ParseQuantity(q); err != nil {
+			return nil, fmt.Errorf("K8sPerUserConfig.%s = %q: %w", name, q, err)
+		}
 	}
 	restCfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -536,12 +568,12 @@ func (g *K8sPerUserGateway) buildPodSpec(userID, podName string) *corev1.Pod {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("500m"),
-							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourceCPU:    resource.MustParse(g.cfg.CPURequest),
+							corev1.ResourceMemory: resource.MustParse(g.cfg.MemoryRequest),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("2000m"),
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourceCPU:    resource.MustParse(g.cfg.CPULimit),
+							corev1.ResourceMemory: resource.MustParse(g.cfg.MemoryLimit),
 						},
 					},
 					// Spark s3a reads these from env to build core-site.xml / spark-defaults

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -96,6 +96,14 @@ type KernelGatewaySettings struct {
 	MaxKernels        int           // hard cap on concurrent kernels
 	PullSecret        string        // optional K8s imagePullSecret name (empty → none)
 	CredsResolver     UserCredsResolver
+
+	// Resource requests/limits in k8s quantity format ("500m", "1Gi"). For
+	// docker_per_user mode only the *Limit values apply (Docker has no
+	// "request" concept). Empty → falls back to gateway-internal defaults.
+	PodCPURequest    string
+	PodMemoryRequest string
+	PodCPULimit      string
+	PodMemoryLimit   string
 }
 
 // NewKernelGateway picks an implementation based on settings.Mode.
@@ -123,6 +131,8 @@ func NewKernelGateway(s KernelGatewaySettings) (KernelGateway, error) {
 			MaxContainers: s.MaxKernels,
 			MinIOEndpoint: s.MinIOEndpoint,
 			CredsResolver: s.CredsResolver,
+			CPULimit:      s.PodCPULimit,
+			MemoryLimit:   s.PodMemoryLimit,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("init DockerPerUserGateway: %w", err)
@@ -136,6 +146,10 @@ func NewKernelGateway(s KernelGatewaySettings) (KernelGateway, error) {
 			MaxPods:       s.MaxKernels,
 			PullSecret:    s.PullSecret,
 			CredsResolver: s.CredsResolver,
+			CPURequest:    s.PodCPURequest,
+			MemoryRequest: s.PodMemoryRequest,
+			CPULimit:      s.PodCPULimit,
+			MemoryLimit:   s.PodMemoryLimit,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("init K8sPerUserGateway: %w", err)

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -94,6 +94,15 @@ spec:
             # Tell the in-cluster client which namespace to spawn kernels in.
             - name: KERNEL_POD_NAMESPACE
               value: {{ .Release.Namespace | quote }}
+            # Per-user kernel pod resources. See values.yaml -> kernel.resources.
+            - name: KERNEL_POD_CPU_REQUEST
+              value: {{ .Values.kernel.resources.requests.cpu | quote }}
+            - name: KERNEL_POD_MEMORY_REQUEST
+              value: {{ .Values.kernel.resources.requests.memory | quote }}
+            - name: KERNEL_POD_CPU_LIMIT
+              value: {{ .Values.kernel.resources.limits.cpu | quote }}
+            - name: KERNEL_POD_MEMORY_LIMIT
+              value: {{ .Values.kernel.resources.limits.memory | quote }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           readinessProbe:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -32,6 +32,17 @@ kernel:
   idleMinutes: 30
   # Cluster-wide cap. Prevents one runaway notebook from exhausting nodes.
   maxTotal: 50
+  # Per-user kernel pod resources. Sets the ceiling each user can use;
+  # Spark driver/executor memory is configured by the user at session time
+  # (within these limits). For docker_per_user mode, only the limits apply
+  # (Docker has no separate "request" concept).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
 
 # ─────────────────────────────────────────────────────────────
 # Secrets. Either let the chart create one (default), or point at


### PR DESCRIPTION
<!-- Thanks for contributing to SparkLabX. Please fill in the sections below. -->

## Summary

<!-- What does this PR change, in 1–3 sentences. -->

## Motivation

<!-- Why is this change needed? Link any related issue: Fixes #123 -->

## Changes

<!-- Bulleted list of the concrete changes in this PR. -->
-
-

## Testing

<!-- How did you verify this works? Include commands, screenshots, logs. -->
- [ ] `go test ./...` passes in `backend/`
- [ ] `npm run lint` passes in `frontend/`
- [ ] Manually exercised the affected path locally

## Security / isolation impact

<!-- Required if this PR touches: auth, JWT, MinIO IAM provisioning,
     kernel spawn/lifecycle, storage path handling, RBAC, secrets,
     CORS, or any cross-tenant boundary. Otherwise: "None". -->

## Breaking changes

<!-- Migrations, config keys renamed, removed env vars, etc. Otherwise: "None". -->

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Commits follow the imperative-mood convention
- [ ] Updated documentation if behavior or config changed
- [ ] No secrets, credentials, or real `.env` values are included
