### PR TITLE
feat: CORS wildcard support and Docker/K8s image pre-pulling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ The essentials:
 | `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` | Root creds the backend uses to provision per-user IAM accounts. |
 | `MINIO_WORKSPACE_BUCKET` | Single shared bucket; default `workspace`. |
 | `KERNEL_MODE` | See above. |
-| `CORS_ORIGINS` | Comma-separated list of allowed frontend origins. |
+| `CORS_ORIGINS` | Comma-separated list of allowed frontend origins. Set to `*` to allow all origins during development (automatically reflects the request origin to support credentials and WebSockets). Note: using `*` in production triggers a security warning. |
 
 Frontend OAuth client IDs are baked at build time via `VITE_GOOGLE_CLIENT_ID`
 and `VITE_MICROSOFT_CLIENT_ID/TENANT_ID`.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -111,14 +111,32 @@ func main() {
 
 	router.Use(gin.Recovery())
 	router.Use(requestLogger())
-	router.Use(cors.New(cors.Config{
-		AllowOrigins:     cfg.CORSOrigins,
+	corsConfig := cors.Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
-	}))
+	}
+
+	allowAll := false
+	for _, o := range cfg.CORSOrigins {
+		if o == "*" {
+			allowAll = true
+			break
+		}
+	}
+
+	if allowAll {
+		if cfg.Environment == "production" {
+			log.Warn().Msg("SECURITY WARNING: CORS_ORIGINS is set to '*' in production environment. This makes the application vulnerable to CSRF and CSWSH attacks. Please configure a specific domain name.")
+		}
+		corsConfig.AllowAllOrigins = true
+	} else {
+		corsConfig.AllowOrigins = cfg.CORSOrigins
+	}
+
+	router.Use(cors.New(corsConfig))
 
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok", "service": cfg.ServiceName, "time": time.Now().UTC()})

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -41,6 +41,9 @@ func NewLocalKernelHandler(cfg *config.Config, gateway services.KernelGateway) *
 				if origin == "" {
 					return true
 				}
+				if allowedOrigins["*"] {
+					return true
+				}
 				return allowedOrigins[origin]
 			},
 			ReadBufferSize:  4096,

--- a/chart/templates/kernel-prepuller.yaml
+++ b/chart/templates/kernel-prepuller.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prepuller.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "sparklabx.fullname" . }}-kernel-prepuller
+  labels:
+    {{- include "sparklabx.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "sparklabx.fullname" . }}-kernel-prepuller
+  template:
+    metadata:
+      labels:
+        app: {{ include "sparklabx.fullname" . }}-kernel-prepuller
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: prepuller
+        image: "{{ .Values.image.kernel.repository }}:{{ .Values.image.kernel.tag }}"
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "while true; do sleep 3600; done"]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 10Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,6 +45,12 @@ kernel:
       memory: 4Gi
 
 # ─────────────────────────────────────────────────────────────
+# Pre-pulling image configurations
+# ─────────────────────────────────────────────────────────────
+prepuller:
+  enabled: true
+
+# ─────────────────────────────────────────────────────────────
 # Secrets. Either let the chart create one (default), or point at
 # a pre-existing Secret you manage out-of-band (e.g. via sealed-secrets,
 # external-secrets-operator, or sops).

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -52,6 +52,11 @@ services:
       - postgres
     restart: unless-stopped
 
+  kernel-cache:
+    image: ghcr.io/sparklabx/kernel:latest
+    container_name: sparklabx-kernel-cache
+    entrypoint: ["echo", "Kernel image cached"]
+
   # Shared Jupyter kernel — only used when KERNEL_MODE=shared. Skipped by
   # default thanks to the "shared" profile; bring it up explicitly with:
   #   docker compose -f docker-compose.test.yml --profile shared up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,11 @@ services:
       - postgres
     restart: unless-stopped
 
+  kernel-cache:
+    image: ghcr.io/sparklabx/kernel:latest
+    container_name: sparklabx-kernel-cache
+    entrypoint: ["echo", "Kernel image cached"]
+
   # Shared Jupyter kernel — only used when KERNEL_MODE=shared. Skipped by
   # default thanks to the "shared" profile; bring it up explicitly with:
   #   docker compose --profile shared up jupyter


### PR DESCRIPTION
This PR introduces two main enhancements:

1. **CORS and WebSocket Optimization**:
   - Backend: Added support for CORS wildcard (`*`) by implementing dynamic origin reflection when `CORS_ORIGINS` is set to `*`.
   - WebSocket: Allowed Gorilla Upgrader to bypass CheckOrigin when CORS_ORIGINS is configured as a wildcard, fixing connection timeouts on dev environments.
   - Added security warning log when wildcards are active in production.

2. **Image Pre-pulling Mechanism**:
   - Docker Compose: Introduced a `kernel-cache` service that automatically caches the kernel image on startup and exits with 0.
   - Kubernetes: Introduced a lightweight DaemonSet (`kernel-prepuller`) that pre-pulls the Jupyter kernel image on all cluster nodes during Helm install/upgrade, minimizing container launch delays for users.