### PR TITLE
fix(backend): retry database ping on startup (#38) (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       frontend: ${{ steps.f.outputs.frontend }}
       chart:    ${{ steps.f.outputs.chart }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: f
         with:
@@ -45,8 +45,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
@@ -72,7 +72,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
@@ -95,7 +95,7 @@ jobs:
     if: needs.changes.outputs.chart == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: azure/setup-helm@v4
         with:
           version: v3.16.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
         id: changes
         with:
@@ -74,7 +74,7 @@ jobs:
         include: ${{ fromJSON(needs.detect.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/sparklabx/sparklabx/backend
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/gin-contrib/cors v1.7.7
@@ -83,7 +83,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.23.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -188,8 +188,8 @@ golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
 golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1,9 +1,11 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"sync"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog/log"
@@ -16,6 +18,43 @@ var (
 	once sync.Once
 )
 
+// pingWithRetry retries Ping until success or the total budget runs out.
+// On a fresh `helm install`, the postgres pod usually becomes
+// DNS-resolvable a few seconds after the backend starts. Without retry,
+// the first Ping fails with `lookup postgres: no such host`, log.Fatal
+// triggers, k8s restarts the container, and the user sees 2-3
+// CrashLoopBackOff cycles before the deploy settles. The same loop also
+// absorbs short network blips and postgres failovers during normal
+// operation, so it isn't startup-specific.
+func pingWithRetry(d *sql.DB) error {
+	const (
+		maxAttempts = 30               // ~2 min total at the chosen backoff
+		baseDelay   = 1 * time.Second  // first wait
+		maxDelay    = 10 * time.Second // cap each individual wait
+	)
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := d.PingContext(ctx)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				log.Info().Int("attempts", attempt).Msg("database became reachable")
+			}
+			return nil
+		}
+		lastErr = err
+		delay := time.Duration(attempt) * baseDelay
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+		log.Warn().Err(err).Int("attempt", attempt).Int("max", maxAttempts).
+			Dur("retry_in", delay).Msg("waiting for database")
+		time.Sleep(delay)
+	}
+	return fmt.Errorf("database unreachable after %d attempts: %w", maxAttempts, lastErr)
+}
+
 func Init(cfg *config.Config) error {
 	var initErr error
 	once.Do(func() {
@@ -26,7 +65,7 @@ func Init(cfg *config.Config) error {
 			return
 		}
 
-		if err = db.Ping(); err != nil {
+		if err = pingWithRetry(db); err != nil {
 			initErr = fmt.Errorf("failed to ping database: %w", err)
 			return
 		}


### PR DESCRIPTION
* fix(backend): retry database ping on startup instead of crashing

Fixes #37 — backend log.Fatal on first Ping failure caused 2-3 k8s restart cycles on every fresh install while postgres warmed up.

Add pingWithRetry: linear backoff (1s, 2s, 3s, ... capped at 10s), up to 30 attempts (~2 min total budget). Each attempt uses a 5s PingContext deadline so a half-resolved DNS / hung socket can't stall the loop. Failures during retry log at WARN with attempt count and retry delay; the existing 'database connection established' INFO line still fires on success.

The same loop also absorbs short network blips and postgres failovers during normal operation, so it isn't strictly startup-specific.

Verification: on a fresh OrbStack helm install, backend used to CrashLoopBackOff 2-3 times (~80s of restarts) before connecting. With this change, backend stays up and logs a handful of 'waiting for database' warnings until postgres is reachable.

* fix(backend): bump Go 1.26.0 → 1.26.4 + x/net v0.54 → v0.55 (clears 17 CVE)

govulncheck (now wired into CI) flagged 17 stdlib CVE on the v0.1.2 backend, all fixed in Go ≥1.26.4 + golang.org/x/net ≥0.55.0:

  - GO-2026-5039  net/textproto: error injection
  - GO-2026-5038  mime: quadratic WordDecoder.DecodeHeader
  - GO-2026-5037  crypto/x509: slow hostname parsing
  - GO-2026-5026  x/net/idna: punycode label normalization
  - GO-2026-4986  net/mail: quadratic consumeComment
  - GO-2026-4977  net/mail: quadratic consumePhrase
  - GO-2026-4971  net: panic on NUL in Dial/LookupPort (Windows)
  - GO-2026-4947  crypto/x509: chain-building DoS
  - GO-2026-4946  crypto/x509: slow policy validation
  - GO-2026-4918  net/http2: infinite loop on bad SETTINGS_MAX_FRAME_SIZE
  - GO-2026-4870  crypto/tls: 1.3 KeyUpdate DoS
  - GO-2026-4866  crypto/x509: case-sensitive name constraint bypass
  - GO-2026-4865  html/template: JsBraceDepth XSS
  - GO-2026-4602  os: FileInfo escape from Root
  - GO-2026-4601  net/url: IPv6 host literal parsing
  - GO-2026-4600  crypto/x509: malformed cert panic
  - GO-2026-4599  crypto/x509: email constraint enforcement

The Dockerfile already builds against 'golang:1.26-alpine' (auto-tracks latest 1.26 patch) so production images were already on a recent toolchain; the issue was that CI's setup-go reads the go directive in go.mod and was therefore building / scanning with 1.26.0.

Local govulncheck after the bump: 'No vulnerabilities found.'

* ci: bump actions/setup-go@v5 → v6, actions/checkout@v5 → v6 (Node 24)

Same deprecation pattern as the earlier setup-node bump: GitHub will force Node.js 24 on June 16 2026 and remove Node 20 from runners on September 16 2026. Both setup-go@v5 and checkout@v5 ran on Node 20; their v6 majors are Node 24-native.

No behavior change expected — same inputs, same outputs.

<!-- Thanks for contributing to SparkLabX. Please fill in the sections below. -->

## Summary

<!-- What does this PR change, in 1–3 sentences. -->

## Motivation

<!-- Why is this change needed? Link any related issue: Fixes #123 -->

## Changes

<!-- Bulleted list of the concrete changes in this PR. -->
-
-

## Testing

<!-- How did you verify this works? Include commands, screenshots, logs. -->
- [ ] `go test ./...` passes in `backend/`
- [ ] `npm run lint` passes in `frontend/`
- [ ] Manually exercised the affected path locally

## Security / isolation impact

<!-- Required if this PR touches: auth, JWT, MinIO IAM provisioning,
     kernel spawn/lifecycle, storage path handling, RBAC, secrets,
     CORS, or any cross-tenant boundary. Otherwise: "None". -->

## Breaking changes

<!-- Migrations, config keys renamed, removed env vars, etc. Otherwise: "None". -->

## Checklist

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Commits follow the imperative-mood convention
- [ ] Updated documentation if behavior or config changed
- [ ] No secrets, credentials, or real `.env` values are included
