### PR TITLE
ci: drop redundant push trigger from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
+# Runs on every PR into dev / test / main — that's the only path
+# branch protection allows, so post-merge push events would just
+# re-verify the exact same content. The workflow_dispatch trigger
+# stays as an escape hatch for manual re-runs.
 on:
   pull_request:
     branches: [dev, test, main]
-  push:
-    branches: [dev, test]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

\`ci.yml\` runs on both \`pull_request\` and \`push\` events:

\`\`\`yaml
on:
  pull_request:
    branches: [dev, test, main]
  push:
    branches: [dev, test]
\`\`\`

Because branch protection blocks every direct push, the only way code lands on \`dev\`/\`test\` is via a PR merge. That means every PR triggers CI **twice** — once on PR open/sync, once on the squashed commit landing on the target branch. Two runs verify the exact same content.

## Fix

Drop the \`push\` trigger from \`ci.yml\`. PR runs are sufficient. Keep \`workflow_dispatch\` as a manual escape hatch.

\`release.yml\` is untouched — its \`push: branches: [main]\` trigger is the actual build/publish signal, not a verification re-run.

## Cost saving

| | Before | After |
|---|---|---|
| Promotion chain (feature → dev → test → main) | 6 CI runs | 3 CI runs |
| PR open + post-merge | 2 runs | 1 run |
| Feedback latency | 2× | 1× |

## Reference

Matches the canonical pattern in:
- Kubernetes (Prow), VS Code, React, Vercel/Next.js, HashiCorp Terraform — all run CI on PR only, with push to release branches reserved for publication.

## Trade-off

If maintainers ever bypass branch protection to direct-push to dev/test (very rare), no CI runs. Mitigation: \`workflow_dispatch\` lets anyone with write access manually re-run.

## Test plan

- [ ] PR CI runs on this PR (head=ci/..., base=dev)
- [ ] Post-merge: no automatic CI run on dev (will verify after merge)
- [ ] Existing PRs #38, #42 not affected — they still run on PR events