### PR TITLE
feat+fix: interrupt button (#45) + busy-aware reaper (#44)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -208,6 +208,7 @@ func main() {
 			// Local kernel proxy
 			nb.POST("/:id/kernel/connect", localKernelHandler.Connect)
 			nb.GET("/:id/kernel/status", localKernelHandler.Status)
+			nb.POST("/:id/kernel/interrupt", localKernelHandler.Interrupt)
 			nb.DELETE("/:id/kernel/disconnect", localKernelHandler.Disconnect)
 			nb.DELETE("/:id/kernel/shutdown", localKernelHandler.Shutdown)
 			nb.Any("/:id/kernel/ws/:kernelId/*path", localKernelHandler.WebSocket)

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -521,6 +521,56 @@ func (h *LocalKernelHandler) Status(c *gin.Context) {
 	})
 }
 
+// Interrupt cancels whatever the kernel is currently executing without
+// restarting it (SIGINT → KeyboardInterrupt in Python / cancel in Almond).
+// Spark catches the interrupt and cancels the active job, but the
+// SparkSession + variables + cached DataFrames survive — exactly the
+// "stop this query, keep my state" UX users reach for after a misclick.
+//
+// POST /api/v1/notebooks/:id/kernel/interrupt
+func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
+	notebookID := c.Param("id")
+	if !checkNotebookWriteAccess(c, notebookID) {
+		return
+	}
+	userID := userIDString(c)
+	kernelKey := kernelKeyForNotebook(notebookID, userID)
+
+	kernelMapMu.Lock()
+	kernelID := kernelMap[kernelKey]
+	kernelMapMu.Unlock()
+	if kernelID == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no active kernel"})
+		return
+	}
+
+	h.gateway.Touch(userID)
+
+	gatewayURL, ok := h.gatewayURLFor(c, userID)
+	if !ok {
+		return
+	}
+
+	url := gatewayURL + "/api/kernels/" + kernelID + "/interrupt"
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		log.Error().Err(err).Str("kernel_id", kernelID).Msg("interrupt: failed to reach gateway")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to reach kernel gateway"})
+		return
+	}
+	defer resp.Body.Close()
+
+	// Jupyter returns 204 on success. Anything else is a gateway issue.
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		log.Warn().Int("status", resp.StatusCode).Str("kernel_id", kernelID).Msg("interrupt: unexpected gateway response")
+		c.JSON(http.StatusBadGateway, gin.H{"error": "gateway rejected interrupt"})
+		return
+	}
+
+	log.Info().Str("kernel_id", kernelID).Str("user_id", userID).Msg("kernel interrupted")
+	c.JSON(http.StatusOK, gin.H{"status": "interrupted", "kernel_id": kernelID})
+}
+
 // Disconnect closes the WebSocket but keeps the kernel alive.
 // DELETE /api/v1/notebooks/:id/kernel/disconnect
 func (h *LocalKernelHandler) Disconnect(c *gin.Context) {

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -555,23 +555,37 @@ func (g *DockerPerUserGateway) reaperLoop() {
 func (g *DockerPerUserGateway) reapIdle() {
 	cutoff := time.Now().Add(-g.cfg.IdleTimeout)
 	rows, err := database.GetDB().Query(
-		`SELECT user_id FROM user_kernel_pods WHERE last_used_at < $1 AND status = $2`,
+		`SELECT user_id, pod_url FROM user_kernel_pods WHERE last_used_at < $1 AND status = $2`,
 		cutoff, PhaseReady,
 	)
 	if err != nil {
 		return
 	}
 	defer rows.Close()
-	var users []string
+	type victim struct{ userID, podURL string }
+	var victims []victim
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err == nil {
-			users = append(users, id)
+		var v victim
+		if err := rows.Scan(&v.userID, &v.podURL); err == nil {
+			victims = append(victims, v)
 		}
 	}
-	for _, u := range users {
-		log.Info().Str("user", u).Msg("reaping idle kernel container")
-		_ = g.Destroy(u)
+	rows.Close()
+
+	db := database.GetDB()
+	for _, v := range victims {
+		// Same protection as the k8s reaper (issue #44): a closed browser
+		// tab freezes last_used_at, but the kernel may still be running a
+		// long Spark job. Skip reap if any kernel reports execution_state
+		// == "busy" and bump last_used_at so we recheck at half-interval.
+		if kernelBusy(v.podURL) {
+			log.Info().Str("user", v.userID).Msg("reapIdle: skipping, kernel is busy")
+			db.Exec(`UPDATE user_kernel_pods SET last_used_at = $1 WHERE user_id = $2`,
+				time.Now().Add(-g.cfg.IdleTimeout/2), v.userID)
+			continue
+		}
+		log.Info().Str("user", v.userID).Msg("reaping idle kernel container")
+		_ = g.Destroy(v.userID)
 	}
 }
 

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -724,12 +726,49 @@ func (g *K8sPerUserGateway) reaperLoop() {
 	}
 }
 
+// kernelBusy queries the Jupyter Kernel Gateway on the pod and reports
+// whether any kernel is currently executing a cell. Returns false on any
+// error (unreachable pod, HTTP timeout, malformed response) so the reaper
+// can still kill genuinely dead pods.
+//
+// This is the fix for the long-running-cell-killed-by-reaper bug
+// (issue #44): a user starts a 45-min Spark job, closes the tab,
+// `last_used_at` freezes, and 30 min later the reaper used to delete
+// the pod mid-execution. With this check, the reaper only kills pods
+// whose kernel reports `execution_state == "idle"`.
+func kernelBusy(podURL string) bool {
+	if podURL == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(podURL + "/api/kernels")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return false
+	}
+	defer resp.Body.Close()
+	var kernels []struct {
+		ExecutionState string `json:"execution_state"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&kernels); err != nil {
+		return false
+	}
+	for _, k := range kernels {
+		if k.ExecutionState == "busy" {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *K8sPerUserGateway) reapOnce() {
 	db := database.GetDB()
 	cutoff := time.Now().Add(-g.cfg.IdleTimeout)
 
 	rows, err := db.Query(
-		`SELECT user_id, pod_name FROM user_kernel_pods
+		`SELECT user_id, pod_name, pod_url FROM user_kernel_pods
 		 WHERE status = $1 AND last_used_at < $2`,
 		PhaseReady, cutoff,
 	)
@@ -739,17 +778,28 @@ func (g *K8sPerUserGateway) reapOnce() {
 	}
 	defer rows.Close()
 
-	type victim struct{ userID, podName string }
+	type victim struct{ userID, podName, podURL string }
 	var victims []victim
 	for rows.Next() {
 		var v victim
-		if err := rows.Scan(&v.userID, &v.podName); err == nil {
+		if err := rows.Scan(&v.userID, &v.podName, &v.podURL); err == nil {
 			victims = append(victims, v)
 		}
 	}
 	rows.Close()
 
 	for _, v := range victims {
+		// Don't kill a pod whose kernel is mid-execution — the user is
+		// probably running a long Spark job with the tab closed.
+		if kernelBusy(v.podURL) {
+			log.Info().Str("user_id", v.userID).Str("pod", v.podName).
+				Msg("reaper: skipping idle reap, kernel is busy")
+			// Bump last_used_at so we don't re-check every minute while the
+			// job runs — recheck in IdleTimeout/2 instead.
+			db.Exec(`UPDATE user_kernel_pods SET last_used_at = $1 WHERE user_id = $2`,
+				time.Now().Add(-g.cfg.IdleTimeout/2), v.userID)
+			continue
+		}
 		err := g.client.CoreV1().Pods(g.cfg.Namespace).Delete(context.Background(), v.podName, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			log.Warn().Err(err).Str("pod", v.podName).Msg("reaper: failed to delete pod")

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import {
     Plus,
     Play,
+    Square,
     Trash2,
     Loader2,
     MoreVertical,
@@ -1181,6 +1182,22 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         return '';
     }).filter(Boolean).join('\n');
 
+    // Interrupt whatever the kernel is currently executing. SIGINT travels to
+    // Python (KeyboardInterrupt) / Almond (cancel cell) and Spark catches it to
+    // cancel the active job. Kernel session + variables + cached DataFrames
+    // survive — exactly the "stop this query, keep my state" gesture users
+    // reach for after misclicking Run on the wrong cell.
+    const handleInterrupt = async () => {
+        if (!notebookId) return;
+        try {
+            await axios.post(`/api/v1/notebooks/${notebookId}/kernel/interrupt`);
+            toast.success('Kernel interrupted');
+        } catch (err) {
+            const e = err as { response?: { data?: { error?: string } } };
+            toast.error(e.response?.data?.error || 'Failed to interrupt kernel');
+        }
+    };
+
     const handleClearOutput = async (cellId: string) => {
         // Clear memory state immediately for UX
         clearCellOutput(cellId);
@@ -1581,21 +1598,38 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             )}
                         </button>
 
-                        <Button
-                            size="sm"
-                            className={`${toolbarBtnBase} ${toolbarBtnCompact} bg-green-600 hover:bg-green-700 text-white border-0`}
-                            onClick={() => {
-                                const sortedCells = [...cells]
-                                    .sort((a, b) => a.order - b.order)
-                                    .map(c => ({ id: c.id, code: c.source, type: c.type }));
-                                executeAllCells(sortedCells);
-                            }}
-                            disabled={connectionStatus !== 'connected' || runningCells.size > 0 || pendingCells.size > 0}
-                            title="Run All Cells"
-                        >
-                            <Play className="size-3 fill-current" />
-                            {!compactToolbar && <span>Run All</span>}
-                        </Button>
+                        {(() => {
+                            const isExecuting = runningCells.size > 0 || pendingCells.size > 0;
+                            return (
+                                <Button
+                                    size="sm"
+                                    className={`${toolbarBtnBase} ${toolbarBtnCompact} ${
+                                        isExecuting
+                                            ? 'bg-red-600 hover:bg-red-700 text-white border-0'
+                                            : 'bg-green-600 hover:bg-green-700 text-white border-0'
+                                    }`}
+                                    onClick={() => {
+                                        if (isExecuting) {
+                                            handleInterrupt();
+                                        } else {
+                                            const sortedCells = [...cells]
+                                                .sort((a, b) => a.order - b.order)
+                                                .map(c => ({ id: c.id, code: c.source, type: c.type }));
+                                            executeAllCells(sortedCells);
+                                        }
+                                    }}
+                                    disabled={connectionStatus !== 'connected'}
+                                    title={isExecuting ? 'Stop execution' : 'Run All Cells'}
+                                >
+                                    {isExecuting ? (
+                                        <Square className="size-3 fill-current" />
+                                    ) : (
+                                        <Play className="size-3 fill-current" />
+                                    )}
+                                    {!compactToolbar && <span>{isExecuting ? 'Stop' : 'Run All'}</span>}
+                                </Button>
+                            );
+                        })()}
 
                         {/* Clear All Outputs button */}
                         <Button
@@ -1741,6 +1775,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                                 language={notebook.language.toLowerCase()}
                                                 onUpdate={(source) => handleUpdateCell(cell.id, source)}
                                                 onRun={(sourceOverride?: string) => handleRunCell(cell.id, sourceOverride ?? cell.source)}
+                                                onInterrupt={handleInterrupt}
                                                 onClearOutput={() => handleClearOutput(cell.id)}
                                                 onDelete={() => handleDeleteCell(cell.id)}
                                                 onMoveUp={() => handleMoveCell(cell.id, 'up')}

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -1603,6 +1603,11 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             return (
                                 <Button
                                     size="sm"
+                                    // "Run All" and "Stop All" are both 7-char, so the
+                                    // natural width is already nearly identical — a small
+                                    // min-width prevents the 2-3px jitter without padding
+                                    // the button out.
+                                    style={{ minWidth: compactToolbar ? undefined : 82 }}
                                     className={`${toolbarBtnBase} ${toolbarBtnCompact} ${
                                         isExecuting
                                             ? 'bg-red-600 hover:bg-red-700 text-white border-0'
@@ -1626,7 +1631,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                     ) : (
                                         <Play className="size-3 fill-current" />
                                     )}
-                                    {!compactToolbar && <span>{isExecuting ? 'Stop' : 'Run All'}</span>}
+                                    {!compactToolbar && <span>{isExecuting ? 'Stop All' : 'Run All'}</span>}
                                 </Button>
                             );
                         })()}

--- a/frontend/src/components/Notebooks/parts/CellEditor.tsx
+++ b/frontend/src/components/Notebooks/parts/CellEditor.tsx
@@ -3,6 +3,7 @@ import Editor from '@monaco-editor/react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import {
     Play,
+    Square,
     Loader2,
     Clock,
     ChevronUp,
@@ -36,6 +37,7 @@ interface CellEditorProps {
     readOnly?: boolean;
     onUpdate: (source: string) => void;
     onRun: (sourceOverride?: string) => void;
+    onInterrupt?: () => void;  // Stop the currently-executing cell (kernel SIGINT)
     onClearOutput: () => void;
     onDelete: () => void;
     onMoveUp: () => void;
@@ -54,6 +56,7 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
     language,
     onUpdate,
     onRun,
+    onInterrupt,
     onClearOutput,
     onDelete,
     onMoveUp,
@@ -152,11 +155,17 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-6 w-6"
-                                onClick={() => onRun()}
-                                disabled={isRunning || isPending || readOnly || kernelBusy}
+                                className={`h-6 w-6 ${isRunning && onInterrupt ? 'text-red-600 hover:text-red-700 hover:bg-red-50' : ''}`}
+                                onClick={() => {
+                                    if (isRunning && onInterrupt) onInterrupt();
+                                    else onRun();
+                                }}
+                                disabled={isPending || readOnly || (isRunning && !onInterrupt) || (!isRunning && kernelBusy)}
+                                title={isRunning ? 'Interrupt cell' : isPending ? 'Queued' : 'Run cell'}
                             >
-                                {isRunning ? (
+                                {isRunning && onInterrupt ? (
+                                    <Square className="h-3.5 w-3.5 fill-current" />
+                                ) : isRunning ? (
                                     <Loader2 className="h-4 w-4 animate-spin" />
                                 ) : isPending ? (
                                     <Clock className="h-4 w-4 text-amber-500" />

--- a/frontend/src/components/Notebooks/parts/CellEditor.tsx
+++ b/frontend/src/components/Notebooks/parts/CellEditor.tsx
@@ -164,7 +164,7 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
                                 title={isRunning ? 'Interrupt cell' : isPending ? 'Queued' : 'Run cell'}
                             >
                                 {isRunning && onInterrupt ? (
-                                    <Square className="h-3.5 w-3.5 fill-current" />
+                                    <Square className="h-3 w-3" strokeWidth={2.5} />
                                 ) : isRunning ? (
                                     <Loader2 className="h-4 w-4 animate-spin" />
                                 ) : isPending ? (
@@ -173,18 +173,18 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
                                     <Play className="h-4 w-4" />
                                 )}
                             </Button>
-                            {(output && output.length > 0) && (
-                                <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                                    onClick={onClearOutput}
-                                    disabled={readOnly}
-                                    title="Clear output"
-                                >
-                                    <Eraser className="h-4 w-4" />
-                                </Button>
-                            )}
+                            {/* Clear always rendered (disabled when no output) so other action
+                                icons don't shift left/right when output appears mid-run. */}
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                                onClick={onClearOutput}
+                                disabled={readOnly || !output || output.length === 0}
+                                title="Clear output"
+                            >
+                                <Eraser className="h-4 w-4" />
+                            </Button>
                         </>
                     )}
                     <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onMoveUp} disabled={readOnly}>


### PR DESCRIPTION
Two related fixes batched. Both touch the kernel-execution lifecycle, so reviewing them together saves context-switching.

## 1. Interrupt button — closes #45

The only way to stop a running cell was to restart the kernel and lose every variable. Now there's a Stop button per cell, and the "Run All" toolbar button morphs into "Stop" while execution is in progress.

### Backend
- New endpoint: \`POST /api/v1/notebooks/:id/kernel/interrupt\`
- Proxies to Jupyter Kernel Gateway \`POST /api/kernels/:id/interrupt\` (SIGINT to kernel)
- Python → \`KeyboardInterrupt\`; Almond → cancel current cell; Spark → cancel active job
- Kernel session, imports, variables, cached DataFrames all survive

### Frontend
- \`CellEditor\`: per-cell Run button morphs into Stop (red \`Square\` icon) while \`isRunning\`. Same UX as Databricks / VS Code / Hex.
- \`NotebookPage\`: toolbar "Run All" morphs into "Stop" while any cell is running or queued.
- Both routes call the same \`handleInterrupt()\` helper that POSTs the new endpoint and shows a toast.

## 2. Busy-aware reaper — closes #44

Users running long Spark jobs (>30 min) lost them whenever they closed the browser tab — the idle reaper kept deleting "idle" pods that were actually mid-execution.

### Root cause

\`reapOnce\` looked only at \`last_used_at\` (refreshed by WS message proxying). Tab closed → no more WS messages → \`last_used_at\` freezes → 30 min later the pod gets killed mid-job.

### Fix

New \`kernelBusy(podURL)\` helper queries the pod's Jupyter Kernel Gateway (\`GET /api/kernels\`) with a 3-second timeout and returns true if any kernel reports \`execution_state == "busy"\`. Reaper now checks this before deleting an idle-looking pod. If busy → skip + bump \`last_used_at\` to (now − IdleTimeout/2) so the recheck happens at half-interval rather than every minute.

Failure modes (gateway unreachable / timeout / malformed body) return false → reaper still cleans up genuinely dead pods.

## Test plan

- [ ] Backend: \`go vet ./... && go build ./...\` — done locally
- [ ] Frontend: \`npx eslint src/...\` — done locally
- [ ] Manual: run a cell with \`time.sleep(60)\`, click Stop within 5 sec → cell goes idle, variables survive
- [ ] Manual: \`spark.read.parquet(...).count()\` over a slow read, close tab, wait 31 min, kernel pod is NOT reaped while \`execution_state=busy\`
- [ ] Manual: idle pod with no kernels, wait 31 min, pod IS reaped as before
- [ ] CI: govulncheck + lint passing