### PR TITLE
feat+fix: live cell execution timer + kernel-busy guard

### DIFF
--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -162,6 +162,7 @@ export default function NotebookPage() {
         executeAllCells,
         pendingCells,
         executionCounts,
+        executionTimes,
         restoreOutputs,
         clearCellOutput,
         waitForReady,
@@ -1495,7 +1496,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         source: c.source,
         order: c.order,
         output: c.last_output?.output as CellOutput[] | undefined,
-        executionTime: c.last_execution_time_ms,
+        // Prefer the live in-session duration (captured by useJupyterKernel on
+        // execute_reply) over the persisted last_execution_time_ms, so the
+        // badge updates immediately when the cell finishes — no DB round-trip.
+        executionTime: executionTimes[c.id] ?? c.last_execution_time_ms,
         last_output: c.last_output as { outputs?: CellOutput[]; executed?: boolean } | undefined,
         _frontendId: (c as any)._frontendId, // Pass through stable ID
     }));

--- a/frontend/src/components/Notebooks/parts/CellEditor.tsx
+++ b/frontend/src/components/Notebooks/parts/CellEditor.tsx
@@ -81,6 +81,24 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
     const monacoLanguage = language === 'scala' ? 'scala' : language === 'sql' ? 'sql' : 'python';
     const isMarkdown = cell.type === 'markdown';
 
+    // Live execution timer — ticks every 100ms while isRunning so users
+    // running long Spark jobs (often minutes) can see elapsed time without
+    // waiting for the final 'executionTime' badge that appears only on
+    // completion. Format matches the final badge (`N.NNs`, 2 decimals).
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
+    useEffect(() => {
+        if (!isRunning) {
+            setElapsedSeconds(0);
+            return;
+        }
+        const startedAt = Date.now();
+        setElapsedSeconds(0);
+        const id = setInterval(() => {
+            setElapsedSeconds((Date.now() - startedAt) / 1000);
+        }, 100);
+        return () => clearInterval(id);
+    }, [isRunning]);
+
     // Local source state to prevent cursor jumping on parent re-render
     const [localSource, setLocalSource] = useState(cell.source || '');
     const prevCellIdRef = useRef(cell.id);
@@ -131,7 +149,9 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
                     {isRunning && cell.type === 'code' && (
                         <div className="flex items-center gap-1 text-blue-500 shrink-0">
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            <span className="text-xs">Running</span>
+                            <span className="text-xs font-mono tabular-nums">
+                                {elapsedSeconds.toFixed(2)}s
+                            </span>
                         </div>
                     )}
                     {hasExecuted && cell.type === 'code' && !isRunning && !isPending && (

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -57,8 +57,9 @@ interface KernelSession {
     runningCells: Set<string>;
     pendingCells: Set<string>;  // Track cells queued for execution (Run All)
     executionCounts: Record<string, number>;  // Cell ID → execution count (In [N]:)
+    executionTimes: Record<string, number>;   // Cell ID → last execution duration (ms) for this session
     executedCells: Set<string>;  // Track cells that have completed execution
-    pendingExecutions: Map<string, { cellId: string; resolve: () => void; hadError?: boolean }>;
+    pendingExecutions: Map<string, { cellId: string; resolve: () => void; hadError?: boolean; startedAt: number }>;
     pendingCompletions: Map<string, { resolve: (result: CompletionResult) => void }>;
     pendingInspections: Map<string, { resolve: (result: InspectionResult) => void }>;
 }
@@ -96,6 +97,7 @@ class KernelSessionManager {
                 runningCells: new Set(),
                 pendingCells: new Set(),
                 executionCounts: {},
+                executionTimes: {},
                 executedCells: new Set(),
                 pendingExecutions: new Map(),
                 pendingCompletions: new Map(),
@@ -404,11 +406,22 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                     newExecCounts[cellId] = userMax + 1;
                 }
 
+                // Record actual execution duration for this cell. Backed by the
+                // startedAt timestamp we stamped into pendingExecutions when
+                // execute_request was sent. Used by the cell badge so the user
+                // sees "1.23s" right after the cell finishes, without waiting
+                // for a DB round-trip via last_execution_time_ms.
+                const newExecTimes = { ...currentSession.executionTimes };
+                if (cellId && execution?.startedAt) {
+                    newExecTimes[cellId] = Date.now() - execution.startedAt;
+                }
+
                 // Update state BEFORE calling resolve()
                 sessionManager.updateSession(notebookId, {
                     runningCells: newRunningCells,
                     executedCells: newExecutedCells,
                     executionCounts: newExecCounts,
+                    executionTimes: newExecTimes,
                 });
 
                 // Delay resolve to let React paint pending state on remaining cells
@@ -956,6 +969,22 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             return;
         }
 
+        // Kernel has a single execution slot — clicking Run on cell B while
+        // cell A is still running would (a) queue B on the kernel side and
+        // (b) make the frontend mark both as 'running'. Then a Stop on
+        // either cell sends one SIGINT that cancels whichever the kernel
+        // happens to be executing, looking to the user like "stopping one
+        // cell also stopped the other". Refuse the second click instead.
+        // Run All has its own queue (executeAllCells chains via onComplete)
+        // and is not affected.
+        const otherRunning = [...session.runningCells].filter(id => id !== cellId);
+        if (otherRunning.length > 0) {
+            toast.warning('Kernel is busy', {
+                description: 'Another cell is running. Wait for it to finish or click Stop on it first.',
+            });
+            return;
+        }
+
         // Policy Check: Skip for system-generated cells and exam mode (kernel proxy).
         // 'init-spark-context' is the auto-init cell injected by NotebookPage.
         const isSystemCell = cellId?.startsWith('spark-connect-')
@@ -1037,10 +1066,13 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             channel: 'shell'
         };
 
-        // Track this execution
+        // Track this execution. startedAt is captured here (vs in execute_reply
+        // metadata) so we measure WS-round-trip-inclusive wall time — what the
+        // user actually waited for, not just kernel CPU time.
         session.pendingExecutions.set(msgId, {
             cellId,
             hadError: false,
+            startedAt: Date.now(),
             resolve: () => {
                 const exec = session.pendingExecutions.get(msgId);
                 if (onComplete) onComplete(exec?.hadError);
@@ -1340,6 +1372,7 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         runningCells: session.runningCells,
         pendingCells: session.pendingCells,
         executionCounts: session.executionCounts,
+        executionTimes: session.executionTimes,
         executedCells: session.executedCells,
         connect,
         checkConnection,


### PR DESCRIPTION
Follow-ups to PR #46 (which has been merged). Three small but
high-impact polish items on cell execution UX.

## 1. Live elapsed-time timer

While a cell is running, the badge ticks every 100ms with the wall-clock elapsed time, formatted as \`N.NNs\` to match the final-time badge. \`tabular-nums\` keeps digit widths consistent so the number doesn't jitter as it counts.

Why it matters: long Spark jobs (often minutes) have no feedback today except the spinning loader. Users assume "stuck" and Ctrl+C prematurely.

## 2. Final time appears immediately after success (was missing)

\`cell.executionTime\` was sourced only from \`last_execution_time_ms\` in the DB, which is only written by manual cell-update API calls. After a fresh \`execute_request → execute_reply\` round trip, the badge stayed empty until the next page reload.

Now \`useJupyterKernel\`:
- stamps \`startedAt: Date.now()\` into \`pendingExecutions\` when the execute_request goes out, and
- computes wall-clock duration in the \`execute_reply\` handler and writes it to a new \`session.executionTimes\` map.

\`NotebookPage\` maps the in-session value first, falling back to \`last_execution_time_ms\` on cold load.

## 3. Block Run while another cell is running

The kernel has a single execution slot. Clicking Run on cell B while cell A was still running used to:
1. add B to \`runningCells\` (now showing 2 'Running' cells),
2. send execute_request to the kernel (which queued B internally),
3. then a Stop click sent SIGINT, cancelling whichever cell the kernel happened to be on — looking to the user like "stopping one cell also stopped the other".

\`executeCell\` now refuses the second click with a toast ('Kernel is busy. Wait or Stop A first.') and returns without touching \`runningCells\`.

Run All is unaffected: \`executeAllCells\` chains via \`onComplete\`, and \`runningCells.size\` is 0 between cells.

## Test plan

- [x] Backend compiles (no backend changes)
- [x] Frontend ESLint clean
- [ ] Manual: long Spark job → live timer ticks; on completion shows final time immediately
- [ ] Manual: cell A running → click Run on cell B → toast appears, B not running
- [ ] Manual: Run All over 3 cells → still chains correctly