### PR TITLE
fix: persist cell execution time across page reload

### DIFF
--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -1084,14 +1084,19 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 const outputs = cellOutputs[cellId] || [];
                 const isExecuted = executedCells.has(cellId);
                 const execCount = executionCounts[cellId];
+                const execTime = executionTimes[cellId];
 
-                // Use existing queue to ensure serialization
+                // Use existing queue to ensure serialization. Persist
+                // last_execution_time_ms so the badge survives a page
+                // reload — without it the in-session executionTimes map
+                // is lost and the cell goes back to showing no duration.
                 queuedUpdateCell(cellId, {
                     last_output: {
                         outputs: outputs,
                         executed: isExecuted
                     },
                     ...(execCount != null ? { execution_count: execCount } : {}),
+                    ...(execTime != null ? { last_execution_time_ms: Math.round(execTime) } : {}),
                 });
             }
             setSaveStatus('saved');


### PR DESCRIPTION
Follow-up to PR #49 — the in-session executionTimes map worked great until you hit F5.

## What was broken

PR #49 captured wall-clock duration into \`session.executionTimes\` so the cell badge could show \`N.NNs\` immediately on \`execute_reply\` without waiting for a DB write. But the value was never sent to the backend, so:

\`\`\`
Run cell  →  badge '12.34s' shows                    ✓
F5 reload →  session state resets, DB has nothing → no badge   ✗
\`\`\`

The fallback chain \`executionTimes[c.id] ?? c.last_execution_time_ms\` always hit the second branch and \`last_execution_time_ms\` was never populated.

## What this changes

\`NotebookPage.saveDirtyCells\` already serializes dirty cells via \`queuedUpdateCell\` (with \`last_output\` and \`execution_count\`). Add \`last_execution_time_ms\` to the same payload when \`executionTimes[cellId]\` is set. Backend accepts the column today — handler already at \`backend/internal/handlers/notebooks.go:466\` writes it to the \`cells\` table. The only missing piece was the frontend including it.

## Behavior after merge

| Moment | Memory | DB | Badge |
|---|---|---|---|
| t=0, cell starts | — | — | live timer ticking |
| t=12.3s, execute_reply | populated | empty (yet) | \`12.34s\` (from memory) |
| t=14.3s, autosave fires | populated | populated | \`12.34s\` (still memory) |
| F5 reload at t=20s | empty (fresh session) | populated | \`12.34s\` (from DB) |

## Cost

Zero new HTTP calls. \`saveDirtyCells\` already PATCHes the cell row; this adds one integer to the existing UPDATE. No new query, no new endpoint, no new index.

## Edge case

If the user reloads in the < 2 s window between \`execute_reply\` and the next autosave tick, the value is lost. Same as any other autosaved field. Acceptable.

## Test plan

- [ ] Run a cell, badge shows N.NNs immediately
- [ ] Wait > 2 s for autosave, F5 reload — badge still shows N.NNs
- [ ] Reload before autosave — badge gone (expected, documented edge case)
- [ ] Run All over 5 cells, reload — all 5 badges restored