### PR TITLE
fix(notebook): no spurious Spark re-init on reload + warn-and-interrupt on leave

### DIFF
--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
+	"github.com/lib/pq"
 	"github.com/rs/zerolog/log"
 
 	"github.com/sparklabx/sparklabx/backend/internal/config"
@@ -528,6 +529,11 @@ func (h *LocalKernelHandler) Status(c *gin.Context) {
 // "stop this query, keep my state" UX users reach for after a misclick.
 //
 // POST /api/v1/notebooks/:id/kernel/interrupt
+// Optional body: { "clear_cells": [...] } — stamps the listed cells'
+// last_output as a KeyboardInterrupt traceback in the same request.
+// Folded together so the page-unload path can fire a single keepalive
+// fetch instead of N+1 (Chrome silently drops the tail when the JS
+// context is being killed).
 func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 	notebookID := c.Param("id")
 	if !checkNotebookWriteAccess(c, notebookID) {
@@ -535,6 +541,11 @@ func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 	}
 	userID := userIDString(c)
 	kernelKey := kernelKeyForNotebook(notebookID, userID)
+
+	var body struct {
+		ClearCells []string `json:"clear_cells"`
+	}
+	_ = c.ShouldBindJSON(&body)
 
 	kernelMapMu.Lock()
 	kernelID := kernelMap[kernelKey]
@@ -567,7 +578,17 @@ func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 		return
 	}
 
-	log.Info().Str("kernel_id", kernelID).Str("user_id", userID).Msg("kernel interrupted")
+	// Without this, the next page load would read the PREVIOUS successful
+	// run's last_output and render the killed cell as if it completed.
+	if len(body.ClearCells) > 0 {
+		const stmt = `UPDATE notebook_cells SET last_output = $1, last_execution_time_ms = NULL, updated_at = NOW() WHERE notebook_id = $2 AND id = ANY($3)`
+		interrupted := []byte(`{"outputs":[{"type":"error","ename":"KeyboardInterrupt","evalue":"Interrupted by tab reload","traceback":["KeyboardInterrupt: Interrupted by tab reload"]}],"executed":true}`)
+		if _, err := database.GetDB().Exec(stmt, interrupted, notebookID, pq.Array(body.ClearCells)); err != nil {
+			log.Warn().Err(err).Str("notebook_id", notebookID).Msg("interrupt: failed to stamp cell outputs")
+		}
+	}
+
+	log.Info().Str("kernel_id", kernelID).Str("user_id", userID).Strs("cleared", body.ClearCells).Msg("kernel interrupted")
 	c.JSON(http.StatusOK, gin.H{"status": "interrupted", "kernel_id": kernelID})
 }
 

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -184,6 +184,7 @@ export default function NotebookPage() {
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
     const [notebookToDelete, setNotebookToDelete] = useState<{ id: string; name: string } | null>(null);
     const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
+    const [pendingNavUrl, setPendingNavUrl] = useState<string | null>(null);
     const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
     const [renameValue, setRenameValue] = useState('');
     const [libraryDialogOpen, setLibraryDialogOpen] = useState(false);
@@ -1128,8 +1129,39 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
 
         const intervalId = setInterval(saveDirtyCells, AUTOSAVE_INTERVAL);
 
-        // Flush all pending saves on browser close/reload
-        const handleBeforeUnload = () => {
+        // Captured in beforeunload (when runningCells is still
+        // populated) and consumed in pagehide. ws.onclose races
+        // with pagehide and resets runningCells to empty, so a
+        // direct read inside pagehide would no-op.
+        let unloadCellsSnapshot: string[] = [];
+
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (runningCellsRef.current.size > 0) {
+                unloadCellsSnapshot = Array.from(runningCellsRef.current);
+                e.preventDefault();
+                e.returnValue = '';
+                return;
+            }
+            unloadCellsSnapshot = [];
+        };
+
+        const handlePageHide = () => {
+            if (unloadCellsSnapshot.length > 0 && notebookRef.current) {
+                const token = localStorage.getItem('sparklabx_token');
+                const clearable = unloadCellsSnapshot.filter(
+                    (id) => id !== 'init-spark-context' && !id.startsWith('spark-connect-')
+                );
+                fetch(`/api/v1/notebooks/${notebookRef.current.id}/kernel/interrupt`, {
+                    method: 'POST',
+                    keepalive: true,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                    },
+                    body: JSON.stringify({ clear_cells: clearable }),
+                }).catch(() => { /* best effort */ });
+            }
+
             // Flush pending source debounce timers via synchronous XHR (sendBeacon only supports POST)
             if (notebookRef.current) {
                 Object.entries(updateCellTimerRef.current).forEach(([cellId, timer]) => {
@@ -1150,10 +1182,12 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
             saveDirtyCells();
         };
         window.addEventListener('beforeunload', handleBeforeUnload);
+        window.addEventListener('pagehide', handlePageHide);
 
         return () => {
             clearInterval(intervalId);
             window.removeEventListener('beforeunload', handleBeforeUnload);
+            window.removeEventListener('pagehide', handlePageHide);
             saveDirtyCells();
         };
     }, [cellOutputs, executedCells, queuedUpdateCell]);
@@ -1211,6 +1245,14 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         if (o?.type === 'result' && o?.data) return JSON.stringify(o.data, null, 2);
         return '';
     }).filter(Boolean).join('\n');
+
+    const guardedNavigate = useCallback((url: string) => {
+        if (runningCellsRef.current.size > 0) {
+            setPendingNavUrl(url);
+            return;
+        }
+        navigate(url);
+    }, [navigate]);
 
     // Interrupt whatever the kernel is currently executing. SIGINT travels to
     // Python (KeyboardInterrupt) / Almond (cancel cell) and Spark catches it to
@@ -1310,7 +1352,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                         >
                                             <span
                                                 className="truncate cursor-pointer flex-1"
-                                                onClick={() => navigate(`/notebooks/${nb.id}`)}
+                                                onClick={() => guardedNavigate(`/notebooks/${nb.id}`)}
                                             >
                                                 {nb.name}
                                             </span>
@@ -1513,7 +1555,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         return (
             <div className="flex flex-col items-center justify-center h-screen gap-4">
                 <p className="text-red-500">{error || 'Notebook not found'}</p>
-                <Button onClick={() => navigate('/notebooks')}>Back to Notebooks</Button>
+                <Button onClick={() => guardedNavigate('/notebooks')}>Back to Notebooks</Button>
             </div>
         );
     }
@@ -2078,6 +2120,38 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                         </AlertDialogAction>
                         <AlertDialogAction className="bg-amber-500 text-white hover:bg-amber-600" onClick={confirmDisconnect}>
                             Disconnect
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog open={pendingNavUrl !== null} onOpenChange={(open) => { if (!open) setPendingNavUrl(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Cell is still running</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Leaving this notebook will interrupt the running cell on the kernel.
+                            <br /><br />
+                            <strong>Continue</strong> — interrupt the cell and switch.
+                            <br />
+                            <strong>Cancel</strong> — stay here.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            className="bg-amber-500 text-white hover:bg-amber-600"
+                            onClick={async () => {
+                                const target = pendingNavUrl;
+                                setPendingNavUrl(null);
+                                if (!target) return;
+                                try {
+                                    await axios.post(`/api/v1/notebooks/${notebookId}/kernel/interrupt`);
+                                } catch { /* best effort; navigate anyway */ }
+                                navigate(target);
+                            }}
+                        >
+                            Continue
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -241,6 +241,23 @@ export default function NotebookPage() {
         if (connectionStatus !== 'connected' || !notebookId) return;
         let cancelled = false;
 
+        // Skip re-init when the kernel pod is the SAME one we already
+        // initialized in a previous tab/session. Spark context lives
+        // inside the pod, so a tab reload (or laptop sleep/wake) that
+        // reconnects to the same kernel_id needs no re-init — running
+        // it again clobbers user state and shows a spurious "Booting
+        // Spark…" badge. The localStorage flag is keyed per-notebook
+        // and stores the kernel_id whose init we observed complete;
+        // if the kernel restarts (manual restart or pod respawn), the
+        // new kernel_id won't match and init runs again as normal.
+        const currentKernelId = localStorage.getItem(`sparklabx_kernel_${notebookId}`);
+        const initedKernelId = localStorage.getItem(`sparklabx_spark_inited_${notebookId}`);
+        if (currentKernelId && currentKernelId === initedKernelId) {
+            devLog(`[NotebookPage] Skipping Spark init — kernel ${currentKernelId} already initialized`);
+            setSparkInitPending(false);
+            return;
+        }
+
         void (async () => {
             // Block user execution immediately on connect; init may take a while (first run downloads jars).
             setSparkInitPending(true);
@@ -590,7 +607,14 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                     // If still running, keep the initializing indicator on.
                     setSparkInitPending(!ok && stillRunning);
                     if (!ok && !stillRunning) toast.error('Spark initialization timed out');
-                    if (ok) setSparkInitPending(false);
+                    if (ok) {
+                        setSparkInitPending(false);
+                        // Remember which kernel pod we successfully
+                        // initialized so a tab reload (same pod)
+                        // skips re-init.
+                        const k = localStorage.getItem(`sparklabx_kernel_${notebookId}`);
+                        if (k) localStorage.setItem(`sparklabx_spark_inited_${notebookId}`, k);
+                    }
                 }
             }
         })();

--- a/frontend/src/components/Notebooks/parts/CellEditor.tsx
+++ b/frontend/src/components/Notebooks/parts/CellEditor.tsx
@@ -163,7 +163,7 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
                             )}
                         </div>
                     )}
-                    {cell.executionTime && (
+                    {cell.executionTime && !isRunning && !isPending && (
                         <span className="text-xs text-muted-foreground">
                             {(cell.executionTime / 1000).toFixed(2)}s
                         </span>


### PR DESCRIPTION
## Summary
- Skip the auto-init-Spark useEffect when the page reconnects to the SAME kernel pod (kernel_id persisted in localStorage). Eliminates the spurious \"Booting Spark…\" badge and fake \"Stop All\" button that show up after Cmd+R during a running cell.
- Hide the stale cell.executionTime badge while a cell is running or queued — otherwise the previous run's duration sits next to the live timer.
- Add a leave-with-running-cells flow: native browser prompt for Cmd+R / tab close (intent captured in beforeunload, side-effects deferred to pagehide so Cancel doesn't fire anything), styled AlertDialog for in-app navigation. Confirming sends one keepalive POST to /kernel/interrupt with clear_cells; backend interrupts the kernel and stamps those cells' last_output as a KeyboardInterrupt traceback in the same transaction. Next page load renders an honest \"interrupted\" state instead of the previous successful run.

## Test plan
- [ ] Open notebook, run a long cell (e.g. \`import time; time.sleep(30)\`), Cmd+R, observe no \"Booting Spark…\" / no \"Stop All\" after reconnect (same pod).
- [ ] Run cell, Cmd+R, Cancel → cell keeps running, no interrupt.
- [ ] Run cell, Cmd+R, Leave → reloaded page shows red XCircle + KeyboardInterrupt traceback for that cell; backend log shows \`kernel interrupted\` with \`cleared\` populated.
- [ ] Run cell, click another notebook in the sidebar → styled AlertDialog appears. Cancel keeps you put; Continue interrupts and switches.
- [ ] Run cell to completion, then run again → previous executionTime hidden while live timer is up; reappears after completion.
- [ ] Restart kernel manually → spark init runs again (kernel_id mismatch unblocks).