### PR TITLE
feat(notebook): show 'Disconnecting...' badge during kernel disconnect

### DIFF
--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useAIContext } from '@/contexts/AIContext';
@@ -156,6 +157,7 @@ export default function NotebookPage() {
         connect,
         checkConnection,
         disconnect,
+        markDisconnecting,
         restart,
         trackPodStatus,
         executeCell,
@@ -879,7 +881,15 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
     };
 
     const confirmDisconnect = async () => {
-        setDisconnectConfirmOpen(false);
+        // Force the dialog close to commit in its own React batch
+        // BEFORE the disconnect() status updates. Without flushSync
+        // React 18 automatic batching merges the dialog close and
+        // the 'disconnecting' status into one commit, and the
+        // intermediate state never paints — the badge appears to
+        // stay on "Connected" through the dialog fade-out.
+        flushSync(() => {
+            setDisconnectConfirmOpen(false);
+        });
         await disconnect(); // disconnect returns void, handles errors internally
 
         // Clear from DB/Cache if needed
@@ -2095,7 +2105,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                     <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>
                         <AlertDialogAction className="bg-destructive text-destructive-foreground hover:bg-destructive/90" onClick={async () => {
-                            setDisconnectConfirmOpen(false);
+                            flushSync(() => {
+                                setDisconnectConfirmOpen(false);
+                                markDisconnecting();
+                            });
                             try {
                                 await axios.delete(`/api/v1/notebooks/${notebookId}/kernel/shutdown`);
                                 // Track pod terminate in BG so sidebar shows "Shutting down..." until pod is gone.

--- a/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
@@ -13,6 +13,7 @@ export const ConnectionStatusBadge: React.FC<{
         connecting: { color: 'text-blue-500 animate-pulse', label: 'Connecting...' },
         starting: { color: 'text-amber-500 animate-pulse', label: 'Starting...' },
         connected: { color: 'text-emerald-500', label: 'Connected' },
+        disconnecting: { color: 'text-amber-500 animate-pulse', label: 'Disconnecting...' },
         error: { color: 'text-rose-500', label: 'Error' },
         dead: { color: 'text-rose-600', label: 'Kernel Dead', icon: 'skull' },
     };

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -11,7 +11,7 @@ import { devLog } from '@/lib/debug';
 // Ensure axios interceptors are registered (authService constructor sets up Bearer token)
 import '@/services/authService';
 
-export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'starting' | 'error' | 'dead';
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'starting' | 'disconnecting' | 'error' | 'dead';
 export type NotebookLanguage = 'python' | 'scala' | 'sql';
 
 function isScalaToolingCrash(text: string): boolean {
@@ -917,6 +917,11 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
     const disconnect = useCallback(async () => {
         try {
             const session = sessionManager.getSession(notebookId);
+
+            // Flip the badge to "Disconnecting…" before the DELETE
+            // round-trip so the user gets feedback (k8s_per_user
+            // mode can take a few seconds to ack).
+            sessionManager.updateSession(notebookId, { status: 'disconnecting' });
 
             // Close WebSocket
             if (session.ws) {

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -632,8 +632,12 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             currentSession.pendingInspections.forEach(c => c.resolve({ found: false, data: {}, metadata: {}, status: 'error' }));
             currentSession.pendingInspections.clear();
 
-            // Don't overwrite 'dead' status with 'disconnected' (keep the detailed reason)
-            if (!wasAlreadyDead) {
+            // Don't overwrite 'dead' status with 'disconnected' (keep the detailed reason).
+            // Also don't overwrite 'disconnecting' — that's a user-initiated tear-down in
+            // progress and disconnect() will land the final 'disconnected' itself after
+            // its min-visible delay (otherwise the badge skips the intermediate state).
+            const userTearingDown = currentSession.status === 'disconnecting';
+            if (!wasAlreadyDead && !userTearingDown) {
                 sessionManager.updateSession(notebookId, {
                     ws: null,
                     status: retryInProgress ? 'connecting' : 'disconnected',
@@ -914,6 +918,16 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
     }, [notebookId, kernelProxyUrl, setupWebSocket]);
 
     // Disconnect from kernel
+    // Flip session.status to 'disconnecting' without running the
+    // disconnect side effects. Useful for Shutdown: we want the
+    // badge to show "Disconnecting..." while the backend kills the
+    // kernel, and we need it set BEFORE ws.onclose fires (the
+    // close handler checks this status to know it should leave
+    // status alone instead of overwriting with 'disconnected').
+    const markDisconnecting = useCallback(() => {
+        sessionManager.updateSession(notebookId, { status: 'disconnecting' });
+    }, [notebookId]);
+
     const disconnect = useCallback(async () => {
         try {
             const session = sessionManager.getSession(notebookId);
@@ -928,11 +942,19 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 session.ws.close();
             }
 
-            // Tell backend to disconnect
+            // Tell backend to disconnect. Pair with a min-duration
+            // delay so the intermediate state stays visible long
+            // enough to register on fast (docker-compose) backends
+            // where DELETE often returns in <50ms.
+            const minVisible = new Promise(r => setTimeout(r, 800));
             try {
-                await axios.delete(`/api/v1/notebooks/${notebookId}/kernel/disconnect`);
+                await Promise.all([
+                    axios.delete(`/api/v1/notebooks/${notebookId}/kernel/disconnect`),
+                    minVisible,
+                ]);
             } catch (e) {
                 console.warn(`[JupyterKernel][${notebookId}] Failed to notify backend of disconnect:`, e);
+                await minVisible;
             }
 
             sessionManager.updateSession(notebookId, {
@@ -1383,6 +1405,7 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         checkConnection,
         waitForReady,
         disconnect,
+        markDisconnecting,
         restart,
         trackPodStatus,
         executeCell,


### PR DESCRIPTION
## Summary
Flip the connection badge to amber pulsing **\"Disconnecting…\"** the moment \`disconnect()\` starts, before awaiting the backend DELETE. Without this the badge stays green **\"Connected\"** through the round-trip (which can take several seconds in k8s_per_user mode) and users wonder if the click registered.

Closes #59

## Test plan
- [ ] Click Disconnect → badge immediately shows \"Disconnecting…\" amber pulse
- [ ] After backend ack → badge transitions to \"Disconnected\" slate
- [ ] No regression on Connect / Restart / Shutdown flows