### PR TITLE
feat(notebook): persistent kernel recorder + toolbar layout fixes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -209,6 +209,7 @@ func main() {
 			nb.POST("/:id/kernel/connect", localKernelHandler.Connect)
 			nb.GET("/:id/kernel/status", localKernelHandler.Status)
 			nb.POST("/:id/kernel/interrupt", localKernelHandler.Interrupt)
+			nb.GET("/:id/kernel/active-executions", localKernelHandler.ActiveExecutions)
 			nb.DELETE("/:id/kernel/disconnect", localKernelHandler.Disconnect)
 			nb.DELETE("/:id/kernel/shutdown", localKernelHandler.Shutdown)
 			nb.Any("/:id/kernel/ws/:kernelId/*path", localKernelHandler.WebSocket)

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	"github.com/lib/pq"
 	"github.com/rs/zerolog/log"
 
 	"github.com/sparklabx/sparklabx/backend/internal/config"
@@ -284,6 +283,7 @@ func startKernelCleanup(gw services.KernelGateway) {
 
 			// Drop both cache + DB row for each victim, then kill kernel on gateway.
 			for _, v := range victims {
+				services.StopRecorder(v.kernelID)
 				deleteKernelMap(v.notebookID, v.userID)
 				if v.kernelID == "" {
 					continue
@@ -529,11 +529,6 @@ func (h *LocalKernelHandler) Status(c *gin.Context) {
 // "stop this query, keep my state" UX users reach for after a misclick.
 //
 // POST /api/v1/notebooks/:id/kernel/interrupt
-// Optional body: { "clear_cells": [...] } — stamps the listed cells'
-// last_output as a KeyboardInterrupt traceback in the same request.
-// Folded together so the page-unload path can fire a single keepalive
-// fetch instead of N+1 (Chrome silently drops the tail when the JS
-// context is being killed).
 func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 	notebookID := c.Param("id")
 	if !checkNotebookWriteAccess(c, notebookID) {
@@ -541,11 +536,6 @@ func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 	}
 	userID := userIDString(c)
 	kernelKey := kernelKeyForNotebook(notebookID, userID)
-
-	var body struct {
-		ClearCells []string `json:"clear_cells"`
-	}
-	_ = c.ShouldBindJSON(&body)
 
 	kernelMapMu.Lock()
 	kernelID := kernelMap[kernelKey]
@@ -578,17 +568,7 @@ func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 		return
 	}
 
-	// Without this, the next page load would read the PREVIOUS successful
-	// run's last_output and render the killed cell as if it completed.
-	if len(body.ClearCells) > 0 {
-		const stmt = `UPDATE notebook_cells SET last_output = $1, last_execution_time_ms = NULL, updated_at = NOW() WHERE notebook_id = $2 AND id = ANY($3)`
-		interrupted := []byte(`{"outputs":[{"type":"error","ename":"KeyboardInterrupt","evalue":"Interrupted by tab reload","traceback":["KeyboardInterrupt: Interrupted by tab reload"]}],"executed":true}`)
-		if _, err := database.GetDB().Exec(stmt, interrupted, notebookID, pq.Array(body.ClearCells)); err != nil {
-			log.Warn().Err(err).Str("notebook_id", notebookID).Msg("interrupt: failed to stamp cell outputs")
-		}
-	}
-
-	log.Info().Str("kernel_id", kernelID).Str("user_id", userID).Strs("cleared", body.ClearCells).Msg("kernel interrupted")
+	log.Info().Str("kernel_id", kernelID).Str("user_id", userID).Msg("kernel interrupted")
 	c.JSON(http.StatusOK, gin.H{"status": "interrupted", "kernel_id": kernelID})
 }
 
@@ -625,6 +605,12 @@ func (h *LocalKernelHandler) Shutdown(c *gin.Context) {
 	kernelMapMu.Unlock()
 
 	if kernelID != "" {
+		// Stop the recorder BEFORE deleting the kernel so its final
+		// flush lands while the kernel's WS is still alive (the
+		// recorder's WS would error out the moment JKG kills the
+		// kernel, dropping any pending in-memory state).
+		services.StopRecorder(kernelID)
+
 		deleteKernelMap(notebookID, userID)
 		gatewayURL, ok := h.gatewayURLFor(c, userID)
 		if !ok {
@@ -727,6 +713,15 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 
 	logger.Info().Msg("local kernel WebSocket proxy established")
 
+	// Lazy-start the persistent recorder so output keeps flowing to
+	// DB even after THIS client closes. Idempotent — subsequent
+	// clients reuse the same recorder.
+	if rec, recErr := services.GetOrCreateRecorder(notebookID, kernelID, targetURL); recErr != nil {
+		logger.Warn().Err(recErr).Msg("failed to start kernel recorder — output persistence disabled for this kernel")
+	} else {
+		_ = rec
+	}
+
 	errChan := make(chan error, 2)
 
 	go func() {
@@ -737,6 +732,11 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 				return
 			}
 			touchKernelLastUsed(kernelKey)
+			// Sniff execute_request so the recorder knows which cell
+			// each subsequent iopub message belongs to.
+			if msgType == websocket.TextMessage {
+				captureExecuteRequest(kernelID, msg)
+			}
 			if err := backendConn.WriteMessage(msgType, msg); err != nil {
 				errChan <- err
 				return
@@ -765,6 +765,85 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 	if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 		logger.Debug().Err(err).Msg("local kernel WebSocket proxy closed")
 	}
+}
+
+// captureExecuteRequest sniffs an outgoing client message; if it's an
+// execute_request carrying metadata.sparklabx_cell_id, register the
+// (msg_id → cell_id) mapping on the kernel's recorder so iopub
+// messages from this execution can be routed to the right cell.
+func captureExecuteRequest(kernelID string, msg []byte) {
+	// Cheap pre-check before JSON parse — execute_request is the only
+	// shell message we care about and most messages aren't that type.
+	if !bytesContains(msg, []byte(`"execute_request"`)) {
+		return
+	}
+	var parsed struct {
+		Header struct {
+			MsgType string `json:"msg_type"`
+			MsgID   string `json:"msg_id"`
+		} `json:"header"`
+		Metadata struct {
+			CellID string `json:"sparklabx_cell_id"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(msg, &parsed); err != nil {
+		return
+	}
+	if parsed.Header.MsgType != "execute_request" || parsed.Metadata.CellID == "" {
+		return
+	}
+	if r := services.GetRecorder(kernelID); r != nil {
+		r.RegisterExecution(parsed.Header.MsgID, parsed.Metadata.CellID)
+	}
+}
+
+// bytesContains is a tiny stdlib-free check; avoids importing "bytes"
+// for one call. Keeps the cheap pre-check fast.
+func bytesContains(haystack, needle []byte) bool {
+	if len(needle) == 0 || len(haystack) < len(needle) {
+		return false
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// ActiveExecutions returns the in-flight executions known to the
+// kernel recorder, used by the FE on mount to rebuild runningCells
+// + pendingExecutions before opening the WebSocket. This is the
+// HTTP state-restore path that replaces WS replay envelopes.
+//
+// GET /api/v1/notebooks/:id/kernel/active-executions
+func (h *LocalKernelHandler) ActiveExecutions(c *gin.Context) {
+	notebookID := c.Param("id")
+	if !checkNotebookWriteAccess(c, notebookID) {
+		return
+	}
+	userID := userIDString(c)
+	kernelKey := kernelKeyForNotebook(notebookID, userID)
+	kernelMapMu.Lock()
+	kernelID := kernelMap[kernelKey]
+	kernelMapMu.Unlock()
+	if kernelID == "" {
+		c.JSON(http.StatusOK, gin.H{"executions": []services.ExecutionRecord{}})
+		return
+	}
+	rec := services.GetRecorder(kernelID)
+	if rec == nil {
+		c.JSON(http.StatusOK, gin.H{"executions": []services.ExecutionRecord{}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"executions": rec.ActiveExecutions()})
 }
 
 // ProxyHTTP proxies REST API calls to the user's kernel gateway.

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -529,6 +530,8 @@ func (h *LocalKernelHandler) Status(c *gin.Context) {
 // "stop this query, keep my state" UX users reach for after a misclick.
 //
 // POST /api/v1/notebooks/:id/kernel/interrupt
+// Forwards SIGINT to the kernel; output flow continues to land in the
+// recorder so the next page load shows the interrupt traceback.
 func (h *LocalKernelHandler) Interrupt(c *gin.Context) {
 	notebookID := c.Param("id")
 	if !checkNotebookWriteAccess(c, notebookID) {
@@ -716,10 +719,8 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 	// Lazy-start the persistent recorder so output keeps flowing to
 	// DB even after THIS client closes. Idempotent — subsequent
 	// clients reuse the same recorder.
-	if rec, recErr := services.GetOrCreateRecorder(notebookID, kernelID, targetURL); recErr != nil {
+	if _, recErr := services.GetOrCreateRecorder(notebookID, kernelID, targetURL); recErr != nil {
 		logger.Warn().Err(recErr).Msg("failed to start kernel recorder — output persistence disabled for this kernel")
-	} else {
-		_ = rec
 	}
 
 	errChan := make(chan error, 2)
@@ -772,9 +773,7 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 // (msg_id → cell_id) mapping on the kernel's recorder so iopub
 // messages from this execution can be routed to the right cell.
 func captureExecuteRequest(kernelID string, msg []byte) {
-	// Cheap pre-check before JSON parse — execute_request is the only
-	// shell message we care about and most messages aren't that type.
-	if !bytesContains(msg, []byte(`"execute_request"`)) {
+	if !bytes.Contains(msg, []byte(`"execute_request"`)) {
 		return
 	}
 	var parsed struct {
@@ -795,27 +794,6 @@ func captureExecuteRequest(kernelID string, msg []byte) {
 	if r := services.GetRecorder(kernelID); r != nil {
 		r.RegisterExecution(parsed.Header.MsgID, parsed.Metadata.CellID)
 	}
-}
-
-// bytesContains is a tiny stdlib-free check; avoids importing "bytes"
-// for one call. Keeps the cheap pre-check fast.
-func bytesContains(haystack, needle []byte) bool {
-	if len(needle) == 0 || len(haystack) < len(needle) {
-		return false
-	}
-	for i := 0; i <= len(haystack)-len(needle); i++ {
-		match := true
-		for j := 0; j < len(needle); j++ {
-			if haystack[i+j] != needle[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
-		}
-	}
-	return false
 }
 
 // ActiveExecutions returns the in-flight executions known to the

--- a/backend/internal/services/kernel_recorder.go
+++ b/backend/internal/services/kernel_recorder.go
@@ -45,14 +45,22 @@ type CellOutput struct {
 // lifetime of one execution; a fresh execution of the same cell
 // creates a new record and supersedes the previous via cellLatest.
 type ExecutionRecord struct {
-	MsgID           string       `json:"msg_id"`
-	CellID          string       `json:"cell_id"`
-	StartedAt       time.Time    `json:"started_at"`
+	MsgID     string    `json:"msg_id"`
+	CellID    string    `json:"cell_id"`
+	StartedAt time.Time `json:"started_at"`
+	// KernelStartedAt is set when iopub status:busy with this
+	// record's msg_id first arrives — i.e. when the kernel
+	// actually picks the execute_request up off its FIFO queue.
+	// Nil while queued; non-nil once running. The FE uses this on
+	// reload restore to put a still-queued cell in pendingCells
+	// instead of runningCells.
+	KernelStartedAt *time.Time   `json:"kernel_started_at,omitempty"`
 	Completed       bool         `json:"completed"`
-	HasError        bool         `json:"has_error"`
 	Outputs         []CellOutput `json:"-"`
 	ExecutionCount  int          `json:"execution_count"`
 	ExecutionTimeMs int64        `json:"execution_time_ms"`
+
+	hasError bool // not exposed; influences DB executed flag only
 }
 
 // KernelRecorder is a singleton per kernel_id. Its WS to JKG stays
@@ -214,6 +222,7 @@ func (r *KernelRecorder) RegisterExecution(msgID, cellID string) {
 		MsgID:     msgID,
 		CellID:    cellID,
 		StartedAt: time.Now(),
+		Outputs:   []CellOutput{}, // non-nil so JSON always serializes as []
 	}
 	r.cellLatest[cellID] = msgID
 }
@@ -281,7 +290,7 @@ func (r *KernelRecorder) ingest(raw []byte) {
 				}
 			}
 		}
-		rec.HasError = true
+		rec.hasError = true
 		rec.Outputs = append(rec.Outputs, CellOutput{
 			Type: "error", Ename: ename, Evalue: evalue, Traceback: tb,
 		})
@@ -296,17 +305,29 @@ func (r *KernelRecorder) ingest(raw []byte) {
 		}
 
 	case "status":
-		// iopub status transitions are the only completion signal
-		// the recorder sees — shell channel's execute_reply only
-		// goes back to the requesting session (the proxy WS), not
-		// us. status:idle with parent = some execute_request means
-		// THAT execution just finished.
+		// iopub status transitions are the only execution lifecycle
+		// signal the recorder sees — shell channel's execute_reply
+		// only goes back to the requesting session (the proxy WS),
+		// not us.
 		state, _ := msg.Content["execution_state"].(string)
-		if state == "idle" {
+		switch state {
+		case "busy":
+			// First busy for an execute_request = kernel just dequeued
+			// it. Stamp so the FE on restore knows this is the running
+			// cell, not a still-queued one.
+			if rec.KernelStartedAt == nil {
+				now := time.Now()
+				rec.KernelStartedAt = &now
+			}
+		case "idle":
 			rec.Completed = true
-			rec.ExecutionTimeMs = time.Since(rec.StartedAt).Milliseconds()
-		} else {
-			return // busy / starting — no DB write needed
+			start := rec.StartedAt
+			if rec.KernelStartedAt != nil {
+				start = *rec.KernelStartedAt
+			}
+			rec.ExecutionTimeMs = time.Since(start).Milliseconds()
+		default:
+			return // starting, etc. — no state change
 		}
 
 	case "clear_output":
@@ -358,9 +379,6 @@ func (r *KernelRecorder) flushOnce() {
 		payload := map[string]interface{}{
 			"outputs":  rec.Outputs,
 			"executed": rec.Completed,
-		}
-		if rec.Outputs == nil {
-			payload["outputs"] = []CellOutput{}
 		}
 		b, err := json.Marshal(payload)
 		if err != nil {

--- a/backend/internal/services/kernel_recorder.go
+++ b/backend/internal/services/kernel_recorder.go
@@ -1,0 +1,407 @@
+// Package services — KernelRecorder maintains a persistent WebSocket
+// to Jupyter Kernel Gateway per kernel, independent of any client. It
+// reads iopub + shell messages, tags each by the cell it belongs to
+// (via msg_id → cell_id mapping registered by the per-client WS proxy
+// on execute_request), and writes accumulated output to the
+// notebook_cells table.
+//
+// This is the foundation for "tab reload preserves running cell" UX:
+// the kernel keeps emitting messages even after the user's WS drops,
+// and the recorder captures them all instead of dropping into the
+// void because JKG has no subscriber.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
+
+	"github.com/sparklabx/sparklabx/backend/internal/database"
+)
+
+const (
+	recorderFlushInterval = 500 * time.Millisecond
+	recorderRetryBackoff  = 2 * time.Second
+)
+
+// CellOutput mirrors the frontend's CellOutput shape so the JSON we
+// persist to cell.last_output matches what the FE expects when it
+// reads the cell back from DB on mount.
+type CellOutput struct {
+	Type      string                 `json:"type"`
+	Text      string                 `json:"text,omitempty"`
+	Data      map[string]interface{} `json:"data,omitempty"`
+	Ename     string                 `json:"ename,omitempty"`
+	Evalue    string                 `json:"evalue,omitempty"`
+	Traceback []string               `json:"traceback,omitempty"`
+}
+
+// ExecutionRecord is the per-execute_request state the recorder
+// builds up as iopub messages arrive. One record lives for the
+// lifetime of one execution; a fresh execution of the same cell
+// creates a new record and supersedes the previous via cellLatest.
+type ExecutionRecord struct {
+	MsgID           string       `json:"msg_id"`
+	CellID          string       `json:"cell_id"`
+	StartedAt       time.Time    `json:"started_at"`
+	Completed       bool         `json:"completed"`
+	HasError        bool         `json:"has_error"`
+	Outputs         []CellOutput `json:"-"`
+	ExecutionCount  int          `json:"execution_count"`
+	ExecutionTimeMs int64        `json:"execution_time_ms"`
+}
+
+// KernelRecorder is a singleton per kernel_id. Its WS to JKG stays
+// open for the life of the kernel pod (independent of clients).
+type KernelRecorder struct {
+	NotebookID string
+	KernelID   string
+	WSURL      string
+
+	conn        *websocket.Conn
+	connWriteMu sync.Mutex
+
+	mu         sync.Mutex
+	records    map[string]*ExecutionRecord // msg_id → record
+	cellLatest map[string]string           // cell_id → latest msg_id (newer runs supersede)
+	dirty      map[string]bool             // cell_id → needs flush
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	stopped  bool
+}
+
+// ── Registry ──────────────────────────────────────────────────────
+
+var (
+	recorders   = make(map[string]*KernelRecorder)
+	recordersMu sync.Mutex
+)
+
+// GetOrCreateRecorder returns the existing recorder for kernelID or
+// starts a new one. wsURL is the JKG channels endpoint
+// (ws://gateway/api/kernels/<id>/channels).
+func GetOrCreateRecorder(notebookID, kernelID, wsURL string) (*KernelRecorder, error) {
+	recordersMu.Lock()
+	defer recordersMu.Unlock()
+	if existing, ok := recorders[kernelID]; ok && !existing.stopped {
+		return existing, nil
+	}
+	r := &KernelRecorder{
+		NotebookID: notebookID,
+		KernelID:   kernelID,
+		WSURL:      wsURL,
+		records:    make(map[string]*ExecutionRecord),
+		cellLatest: make(map[string]string),
+		dirty:      make(map[string]bool),
+		stopCh:     make(chan struct{}),
+	}
+	if err := r.dial(); err != nil {
+		return nil, err
+	}
+	recorders[kernelID] = r
+	go r.readLoop()
+	go r.flushLoop()
+	log.Info().Str("kernel", kernelID).Msg("KernelRecorder: started")
+	return r, nil
+}
+
+// StopRecorder closes the recorder for kernelID. Called when the
+// kernel itself is shut down (handler) or reaped (idle cleanup).
+func StopRecorder(kernelID string) {
+	recordersMu.Lock()
+	r := recorders[kernelID]
+	delete(recorders, kernelID)
+	recordersMu.Unlock()
+	if r != nil {
+		r.stop()
+	}
+}
+
+// GetRecorder returns the recorder for kernelID without creating
+// one. Returns nil if no recorder is registered.
+func GetRecorder(kernelID string) *KernelRecorder {
+	recordersMu.Lock()
+	defer recordersMu.Unlock()
+	if r, ok := recorders[kernelID]; ok && !r.stopped {
+		return r
+	}
+	return nil
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────
+
+func (r *KernelRecorder) dial() error {
+	dialer := websocket.Dialer{HandshakeTimeout: 30 * time.Second}
+	conn, _, err := dialer.Dial(r.WSURL, nil)
+	if err != nil {
+		return err
+	}
+	r.conn = conn
+	return nil
+}
+
+func (r *KernelRecorder) stop() {
+	r.stopOnce.Do(func() {
+		r.stopped = true
+		close(r.stopCh)
+		if r.conn != nil {
+			_ = r.conn.Close()
+		}
+		// Final flush so any pending writes land.
+		r.flushOnce()
+		log.Info().Str("kernel", r.KernelID).Msg("KernelRecorder: stopped")
+	})
+}
+
+// readLoop pumps messages from the kernel into ExecutionRecords.
+// Exits on stop or unrecoverable WS read error.
+func (r *KernelRecorder) readLoop() {
+	defer r.stop()
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		default:
+		}
+		_, msg, err := r.conn.ReadMessage()
+		if err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				log.Debug().Err(err).Str("kernel", r.KernelID).Msg("KernelRecorder: read error")
+			}
+			return
+		}
+		r.ingest(msg)
+	}
+}
+
+// flushLoop wakes every recorderFlushInterval, batches dirty cells'
+// state into DB writes. One UPDATE per dirty cell per tick — cheap.
+func (r *KernelRecorder) flushLoop() {
+	t := time.NewTicker(recorderFlushInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-t.C:
+			r.flushOnce()
+		}
+	}
+}
+
+// ── Public API: register + query ──────────────────────────────────
+
+// RegisterExecution is called by the per-client WS proxy when it sees
+// an execute_request go by, carrying metadata.sparklabx_cell_id so we
+// can tag iopub messages by cell. Without this mapping the recorder
+// would still buffer outputs but couldn't tell which DB row to write
+// them to.
+func (r *KernelRecorder) RegisterExecution(msgID, cellID string) {
+	if msgID == "" || cellID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.records[msgID]; exists {
+		return // idempotent — duplicate registration from retry, etc.
+	}
+	r.records[msgID] = &ExecutionRecord{
+		MsgID:     msgID,
+		CellID:    cellID,
+		StartedAt: time.Now(),
+	}
+	r.cellLatest[cellID] = msgID
+}
+
+// ActiveExecutions returns a snapshot of all in-flight executions
+// for which we know the cell_id. Used by the active-executions
+// endpoint to let the FE rebuild runningCells on mount.
+func (r *KernelRecorder) ActiveExecutions() []ExecutionRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := []ExecutionRecord{}
+	for _, rec := range r.records {
+		if rec.CellID == "" || rec.Completed {
+			continue
+		}
+		out = append(out, *rec) // copy by value
+	}
+	return out
+}
+
+// ── Internal: message ingestion ───────────────────────────────────
+
+func (r *KernelRecorder) ingest(raw []byte) {
+	var msg struct {
+		Channel      string                 `json:"channel"`
+		Header       msgHeader              `json:"header"`
+		ParentHeader msgHeader              `json:"parent_header"`
+		Content      map[string]interface{} `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return // unparseable — drop silently
+	}
+	parentID := msg.ParentHeader.MsgID
+	if parentID == "" {
+		return // can't attribute to an execution
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	rec := r.records[parentID]
+	if rec == nil {
+		return // parent execution not registered (e.g. backend restarted, lost map)
+	}
+
+	switch msg.Header.MsgType {
+	case "stream":
+		text, _ := msg.Content["text"].(string)
+		rec.Outputs = append(rec.Outputs, CellOutput{Type: "stream", Text: text})
+
+	case "display_data", "execute_result":
+		data, _ := msg.Content["data"].(map[string]interface{})
+		rec.Outputs = append(rec.Outputs, CellOutput{Type: "result", Data: data})
+		if cnt, ok := msg.Content["execution_count"].(float64); ok {
+			rec.ExecutionCount = int(cnt)
+		}
+
+	case "error":
+		ename, _ := msg.Content["ename"].(string)
+		evalue, _ := msg.Content["evalue"].(string)
+		var tb []string
+		if raw, ok := msg.Content["traceback"].([]interface{}); ok {
+			for _, t := range raw {
+				if s, ok := t.(string); ok {
+					tb = append(tb, s)
+				}
+			}
+		}
+		rec.HasError = true
+		rec.Outputs = append(rec.Outputs, CellOutput{
+			Type: "error", Ename: ename, Evalue: evalue, Traceback: tb,
+		})
+
+	case "execute_input":
+		// Earliest message in a cycle, carries the In[N] number. We
+		// can't get this from execute_reply because that's a shell
+		// channel point-to-point reply and our recorder has its
+		// own session (only iopub broadcasts reach us).
+		if cnt, ok := msg.Content["execution_count"].(float64); ok {
+			rec.ExecutionCount = int(cnt)
+		}
+
+	case "status":
+		// iopub status transitions are the only completion signal
+		// the recorder sees — shell channel's execute_reply only
+		// goes back to the requesting session (the proxy WS), not
+		// us. status:idle with parent = some execute_request means
+		// THAT execution just finished.
+		state, _ := msg.Content["execution_state"].(string)
+		if state == "idle" {
+			rec.Completed = true
+			rec.ExecutionTimeMs = time.Since(rec.StartedAt).Milliseconds()
+		} else {
+			return // busy / starting — no DB write needed
+		}
+
+	case "clear_output":
+		// Some libraries (tqdm in widget mode) emit this to wipe previous
+		// output before re-rendering. Mirror that here so DB doesn't
+		// keep growing.
+		rec.Outputs = rec.Outputs[:0]
+
+	default:
+		return // comm_*, kernel_info_reply, etc. — not output
+	}
+
+	r.dirty[rec.CellID] = true
+}
+
+type msgHeader struct {
+	MsgID   string `json:"msg_id"`
+	MsgType string `json:"msg_type"`
+}
+
+// ── Internal: DB flush ────────────────────────────────────────────
+
+// flushOnce drains the dirty set and writes each affected cell's
+// latest record to notebook_cells.last_output (+ time/count when
+// completed). Lock-free for the SQL phase — we copy state out under
+// the mutex then release before hitting Postgres.
+func (r *KernelRecorder) flushOnce() {
+	r.mu.Lock()
+	if len(r.dirty) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	type pending struct {
+		cellID  string
+		outputs []byte
+		execMs  *int64
+		execCnt *int
+	}
+	work := make([]pending, 0, len(r.dirty))
+	for cellID := range r.dirty {
+		msgID := r.cellLatest[cellID]
+		if msgID == "" {
+			continue
+		}
+		rec := r.records[msgID]
+		if rec == nil {
+			continue
+		}
+		payload := map[string]interface{}{
+			"outputs":  rec.Outputs,
+			"executed": rec.Completed,
+		}
+		if rec.Outputs == nil {
+			payload["outputs"] = []CellOutput{}
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			continue
+		}
+		p := pending{cellID: cellID, outputs: b}
+		if rec.Completed {
+			ms := rec.ExecutionTimeMs
+			cnt := rec.ExecutionCount
+			p.execMs = &ms
+			if cnt > 0 {
+				p.execCnt = &cnt
+			}
+		}
+		work = append(work, p)
+	}
+	r.dirty = make(map[string]bool)
+	r.mu.Unlock()
+
+	db := database.GetDB()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for _, p := range work {
+		// Three forms: in-progress (just output), completed (+time+count), completed without exec_count yet
+		var err error
+		switch {
+		case p.execMs != nil && p.execCnt != nil:
+			_, err = db.ExecContext(ctx,
+				`UPDATE notebook_cells SET last_output = $1, last_execution_time_ms = $2, execution_count = $3, updated_at = NOW() WHERE id = $4 AND notebook_id = $5`,
+				p.outputs, *p.execMs, *p.execCnt, p.cellID, r.NotebookID)
+		case p.execMs != nil:
+			_, err = db.ExecContext(ctx,
+				`UPDATE notebook_cells SET last_output = $1, last_execution_time_ms = $2, updated_at = NOW() WHERE id = $3 AND notebook_id = $4`,
+				p.outputs, *p.execMs, p.cellID, r.NotebookID)
+		default:
+			_, err = db.ExecContext(ctx,
+				`UPDATE notebook_cells SET last_output = $1, updated_at = NOW() WHERE id = $2 AND notebook_id = $3`,
+				p.outputs, p.cellID, r.NotebookID)
+		}
+		if err != nil {
+			log.Warn().Err(err).Str("cell", p.cellID).Msg("KernelRecorder: flush failed")
+		}
+	}
+}

--- a/frontend/src/components/Admin/StoragePage.tsx
+++ b/frontend/src/components/Admin/StoragePage.tsx
@@ -6,11 +6,12 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { ConfirmDeleteDialog } from '../ui/confirm-delete-dialog';
 import {
   Upload, FileText, Trash2, Download, FolderOpen, Copy, RefreshCw,
-  ChevronLeft, Database, FolderPlus, Plus, HardDrive, Search, Eye,
+  ChevronLeft, Database, FolderPlus, Plus, HardDrive, Globe, Search, Eye,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import axios from 'axios';
 import * as minioService from '../../services/minioStorageService';
+import { getUserDataPath } from '../../services/notebookStorageService';
 import { parseCsv, parseJsonTable } from '../../lib/dataUtils';
 
 const StoragePage: React.FC = () => {
@@ -133,10 +134,34 @@ const StoragePage: React.FC = () => {
     setCurrentPath(parts.length > 0 ? parts.join('/') + '/' : '');
   };
 
+  // Real s3a:// roots for the 'my' / 'public' logical buckets. Without
+  // these the copied path would be s3a://my/... which isn't a real
+  // bucket name and Spark can't read it.
+  const [s3aRoots, setS3aRoots] = useState<{ private: string; public: string }>({ private: '', public: '' });
+  useEffect(() => {
+    (async () => {
+      const info = await getUserDataPath().catch(() => null);
+      const priv = (info as any)?.private_path || info?.path || '';
+      const pub = (info as any)?.public_path || '';
+      setS3aRoots({ private: priv, public: pub });
+    })();
+  }, []);
+
   // Copy path
   const copyPath = (path: string) => {
     navigator.clipboard.writeText(path);
     toast.success('Copied');
+  };
+
+  // Resolve a bucket+key pair to its real s3a:// URI.
+  const buildS3aPath = (bucket: string, key: string): string => {
+    if (bucket === 'my' && s3aRoots.private) {
+      return s3aRoots.private.replace(/\/$/, '') + '/' + key;
+    }
+    if (bucket === 'public' && s3aRoots.public) {
+      return s3aRoots.public.replace(/\/$/, '') + '/' + key;
+    }
+    return `s3a://${bucket}/${key}`;
   };
 
   // Filtered files
@@ -164,7 +189,7 @@ const StoragePage: React.FC = () => {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold flex items-center gap-2"><Database className="h-6 w-6" /> Storage</h1>
         <Button variant="outline" onClick={() => setCreateBucketOpen(true)}>
-          <Plus className="h-4 w-4 mr-1" /> New Bucket
+          <Plus className="h-4 w-4 mr-1" /> New Space
         </Button>
       </div>
 
@@ -172,7 +197,7 @@ const StoragePage: React.FC = () => {
         {/* Bucket list */}
         <Card>
           <CardHeader className="py-3 px-4">
-            <CardTitle className="text-sm">Buckets</CardTitle>
+            <CardTitle className="text-sm">Spaces</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             {buckets.map(b => (
@@ -184,30 +209,42 @@ const StoragePage: React.FC = () => {
                 <button
                   onClick={() => { setSelectedBucket(b.name); setCurrentPath(''); }}
                   className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                  title={b.name}
                 >
-                  <HardDrive className="h-3.5 w-3.5 shrink-0" />
-                  <span className="truncate">{b.name}</span>
+                  {b.name === 'public' ? (
+                    <Globe className="h-3.5 w-3.5 shrink-0" />
+                  ) : (
+                    <HardDrive className="h-3.5 w-3.5 shrink-0" />
+                  )}
+                  <span className="truncate">
+                    {b.name === 'my' ? 'My Space' : b.name === 'public' ? 'Public' : b.name}
+                  </span>
                 </button>
-                <Button size="sm" variant="ghost" className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setConfirmDelete({
-                      type: 'bucket',
-                      name: b.name,
-                      action: async () => {
-                        const ok = await minioService.deleteBucket(b.name);
-                        if (ok) {
-                          toast.success(`Bucket "${b.name}" deleted`);
-                          if (selectedBucket === b.name) setSelectedBucket('');
-                          loadBuckets();
-                        } else {
-                          toast.error('Failed to delete bucket (must be empty)');
-                        }
-                      },
-                    });
-                  }}>
-                  <Trash2 className="h-3 w-3" />
-                </Button>
+                {/* System buckets ('my', 'public') are not user-managed
+                    and shouldn't be deletable from the UI — backend
+                    recreates them on next start anyway. */}
+                {b.name !== 'my' && b.name !== 'public' && (
+                  <Button size="sm" variant="ghost" className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setConfirmDelete({
+                        type: 'bucket',
+                        name: b.name,
+                        action: async () => {
+                          const ok = await minioService.deleteBucket(b.name);
+                          if (ok) {
+                            toast.success(`Bucket "${b.name}" deleted`);
+                            if (selectedBucket === b.name) setSelectedBucket('');
+                            loadBuckets();
+                          } else {
+                            toast.error('Failed to delete bucket (must be empty)');
+                          }
+                        },
+                      });
+                    }}>
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                )}
               </div>
             ))}
             {buckets.length === 0 && (
@@ -219,14 +256,23 @@ const StoragePage: React.FC = () => {
         {/* File browser */}
         <Card>
           <CardHeader className="py-3 px-4 flex flex-row items-center justify-between">
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              {currentPath && (
-                <Button size="sm" variant="ghost" className="h-7 px-2" onClick={navigateUp}>
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-              )}
+            {/* Path bar — reserve the back-arrow slot at root so the
+                path text doesn't shift when entering a subfolder. The
+                bucket name is already shown in the left-hand list, no
+                need to repeat it in the breadcrumb. */}
+            <div className="flex items-center flex-1 min-w-0">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2 shrink-0 disabled:opacity-40"
+                onClick={navigateUp}
+                disabled={!currentPath}
+                title="Go Up"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
               <span className="text-sm font-mono text-muted-foreground truncate">
-                {selectedBucket ? `${selectedBucket}/${currentPath}` : 'Select a bucket'}
+                {selectedBucket ? `/${currentPath}` : 'Select a bucket'}
               </span>
             </div>
             <div className="flex gap-1">
@@ -275,27 +321,27 @@ const StoragePage: React.FC = () => {
             ) : filteredFiles.length === 0 ? (
               <div className="px-4 py-12 text-center text-muted-foreground text-sm">Empty</div>
             ) : (
-              <table className="w-full text-sm">
+              <table className="w-full text-sm table-fixed">
                 <thead>
                   <tr className="border-b text-xs text-muted-foreground">
                     <th className="text-left px-4 py-2 font-medium">Name</th>
                     <th className="text-right px-4 py-2 font-medium w-24">Size</th>
                     <th className="text-right px-4 py-2 font-medium w-44">Modified</th>
-                    <th className="text-right px-4 py-2 font-medium w-28">Actions</th>
+                    <th className="text-right px-4 py-2 font-medium w-40">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {filteredFiles.map(f => (
-                    <tr key={f.key} className="border-b hover:bg-muted/30 group">
-                      <td className="px-4 py-2">
-                        <div className="flex items-center gap-2 cursor-pointer"
+                    <tr key={f.key} className="border-b hover:bg-muted/30 group h-10">
+                      <td className="px-4 py-2 overflow-hidden">
+                        <div className="flex items-center gap-2 cursor-pointer min-w-0"
                           onClick={() => f.is_folder ? navigateFolder(f) : undefined}>
                           {f.is_folder ? (
                             <FolderOpen className="h-4 w-4 text-yellow-500 shrink-0" />
                           ) : (
                             <FileText className="h-4 w-4 text-blue-500 shrink-0" />
                           )}
-                          <span className={f.is_folder ? 'font-medium hover:text-primary' : ''}>{f.name}</span>
+                          <span className={`truncate ${f.is_folder ? 'font-medium hover:text-primary' : ''}`} title={f.name}>{f.name}</span>
                         </div>
                       </td>
                       <td className="px-4 py-2 text-right text-xs text-muted-foreground">
@@ -307,7 +353,7 @@ const StoragePage: React.FC = () => {
                       <td className="px-4 py-2 text-right">
                         <div className="flex justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                           <Button size="sm" variant="ghost" className="h-7 w-7 p-0"
-                            onClick={() => copyPath(`s3a://${selectedBucket}/${f.key}`)} title="Copy S3 path">
+                            onClick={() => copyPath(buildS3aPath(selectedBucket, f.key))} title="Copy S3 path">
                             <Copy className="h-3.5 w-3.5" />
                           </Button>
                           {!f.is_folder && /\.(csv|tsv|json|jsonl|parquet)$/i.test(f.name) && (
@@ -351,9 +397,9 @@ const StoragePage: React.FC = () => {
       <Dialog open={createBucketOpen} onOpenChange={setCreateBucketOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
-            <DialogTitle>Create Bucket</DialogTitle>
+            <DialogTitle>Create Space</DialogTitle>
           </DialogHeader>
-          <Input placeholder="Bucket name" value={newBucketName}
+          <Input placeholder="Space name" value={newBucketName}
             onChange={e => setNewBucketName(e.target.value)}
             onKeyDown={e => { if (e.key === 'Enter') handleCreateBucket(); }}
             autoFocus />
@@ -386,9 +432,9 @@ const StoragePage: React.FC = () => {
         <ConfirmDeleteDialog
           open={!!confirmDelete}
           onOpenChange={() => setConfirmDelete(null)}
-          title={`Delete ${confirmDelete.type === 'bucket' ? 'bucket' : 'file'}?`}
+          title={`Delete ${confirmDelete.type === 'bucket' ? 'space' : 'file'}?`}
           description={confirmDelete.type === 'bucket'
-            ? `Delete bucket "${confirmDelete.name}"? Bucket must be empty.`
+            ? `Delete space "${confirmDelete.name}"? Space must be empty.`
             : `Delete "${confirmDelete.name}"? This action cannot be undone.`}
           confirmText={confirmDelete.name}
           onConfirm={async () => { await confirmDelete.action(); }}

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -153,6 +153,7 @@ export default function NotebookPage() {
         podMessage,
         cellOutputs,
         runningCells,
+        runningCellStarts,
         executedCells,
         connect,
         checkConnection,
@@ -186,7 +187,6 @@ export default function NotebookPage() {
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
     const [notebookToDelete, setNotebookToDelete] = useState<{ id: string; name: string } | null>(null);
     const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
-    const [pendingNavUrl, setPendingNavUrl] = useState<string | null>(null);
     const [renameTarget, setRenameTarget] = useState<{ id: string; name: string } | null>(null);
     const [renameValue, setRenameValue] = useState('');
     const [libraryDialogOpen, setLibraryDialogOpen] = useState(false);
@@ -1139,40 +1139,11 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
 
         const intervalId = setInterval(saveDirtyCells, AUTOSAVE_INTERVAL);
 
-        // Captured in beforeunload (when runningCells is still
-        // populated) and consumed in pagehide. ws.onclose races
-        // with pagehide and resets runningCells to empty, so a
-        // direct read inside pagehide would no-op.
-        let unloadCellsSnapshot: string[] = [];
-
-        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-            if (runningCellsRef.current.size > 0) {
-                unloadCellsSnapshot = Array.from(runningCellsRef.current);
-                e.preventDefault();
-                e.returnValue = '';
-                return;
-            }
-            unloadCellsSnapshot = [];
-        };
-
+        // Flush pending source debounce timers on unload via sync XHR.
+        // No interrupt-on-leave: the backend KernelRecorder keeps writing
+        // cell.last_output as the kernel emits messages, so closing the
+        // tab no longer drops in-flight output.
         const handlePageHide = () => {
-            if (unloadCellsSnapshot.length > 0 && notebookRef.current) {
-                const token = localStorage.getItem('sparklabx_token');
-                const clearable = unloadCellsSnapshot.filter(
-                    (id) => id !== 'init-spark-context' && !id.startsWith('spark-connect-')
-                );
-                fetch(`/api/v1/notebooks/${notebookRef.current.id}/kernel/interrupt`, {
-                    method: 'POST',
-                    keepalive: true,
-                    headers: {
-                        'Content-Type': 'application/json',
-                        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-                    },
-                    body: JSON.stringify({ clear_cells: clearable }),
-                }).catch(() => { /* best effort */ });
-            }
-
-            // Flush pending source debounce timers via synchronous XHR (sendBeacon only supports POST)
             if (notebookRef.current) {
                 Object.entries(updateCellTimerRef.current).forEach(([cellId, timer]) => {
                     clearTimeout(timer);
@@ -1188,15 +1159,12 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 });
                 updateCellTimerRef.current = {};
             }
-            // Also flush dirty output saves
             saveDirtyCells();
         };
-        window.addEventListener('beforeunload', handleBeforeUnload);
         window.addEventListener('pagehide', handlePageHide);
 
         return () => {
             clearInterval(intervalId);
-            window.removeEventListener('beforeunload', handleBeforeUnload);
             window.removeEventListener('pagehide', handlePageHide);
             saveDirtyCells();
         };
@@ -1255,14 +1223,6 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         if (o?.type === 'result' && o?.data) return JSON.stringify(o.data, null, 2);
         return '';
     }).filter(Boolean).join('\n');
-
-    const guardedNavigate = useCallback((url: string) => {
-        if (runningCellsRef.current.size > 0) {
-            setPendingNavUrl(url);
-            return;
-        }
-        navigate(url);
-    }, [navigate]);
 
     // Interrupt whatever the kernel is currently executing. SIGINT travels to
     // Python (KeyboardInterrupt) / Almond (cancel cell) and Spark catches it to
@@ -1362,7 +1322,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                         >
                                             <span
                                                 className="truncate cursor-pointer flex-1"
-                                                onClick={() => guardedNavigate(`/notebooks/${nb.id}`)}
+                                                onClick={() => navigate(`/notebooks/${nb.id}`)}
                                             >
                                                 {nb.name}
                                             </span>
@@ -1565,7 +1525,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         return (
             <div className="flex flex-col items-center justify-center h-screen gap-4">
                 <p className="text-red-500">{error || 'Notebook not found'}</p>
-                <Button onClick={() => guardedNavigate('/notebooks')}>Back to Notebooks</Button>
+                <Button onClick={() => navigate('/notebooks')}>Back to Notebooks</Button>
             </div>
         );
     }
@@ -1614,21 +1574,30 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 <div className="flex items-center justify-between px-2 py-2 border-b border-border bg-background shrink-0 h-12 gap-2 overflow-hidden">
                     <div className="flex items-center gap-2 min-w-0 flex-shrink">
 
-                        {/* Notebook name (read-only) */}
+                        {/* Notebook name (read-only) — fixed size so toolbar
+                            layout doesn't reflow when switching between
+                            notebooks with different name lengths. */}
                         <Input
                             value={notebook.name}
                             readOnly
-                            className={`font-medium text-sm cursor-default ${compactToolbar ? 'w-32 min-w-[100px]' : 'w-56 min-w-[150px]'}`}
+                            title={notebook.name}
+                            className={`font-medium text-sm cursor-default shrink-0 ${compactToolbar ? 'w-32' : 'w-56'}`}
                         />
 
-                        {/* Language display (read-only) */}
+                        {/* Language display (read-only). Fixed text width so
+                            switching between Python/Scala notebooks doesn't
+                            shift the toolbar items to the right of this badge. */}
                         <Badge variant="outline" className="px-2 py-1 text-sm font-medium flex items-center gap-1.5" title={notebook.language}>
                             <img
                                 src={notebook.language.toUpperCase() === 'PYTHON' ? '/icons/languages/python.png' : '/icons/languages/scala.png'}
                                 alt={notebook.language}
                                 className="w-4 h-4"
                             />
-                            {!compactToolbar && <span>{notebook.language.toUpperCase() === 'PYTHON' ? 'Python' : 'Scala'}</span>}
+                            {!compactToolbar && (
+                                <span className="inline-block w-12 text-center">
+                                    {notebook.language.toUpperCase() === 'PYTHON' ? 'Python' : 'Scala'}
+                                </span>
+                            )}
                         </Badge>
 
                         {/* Connection status */}
@@ -1739,12 +1708,15 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             {!compactToolbar && <span>Clear Output</span>}
                         </Button>
 
-                        {/* Connect/Disconnect button */}
+                        {/* Connect/Disconnect button — fixed minWidth so all
+                            four states (Connect / Disconnect / Connecting… /
+                            Shutting down…) take the same horizontal space. */}
                         {connectionStatus === 'connected' ? (
                             <Button
                                 variant="outline"
                                 size="sm"
                                 onClick={handleDisconnect}
+                                style={{ minWidth: compactToolbar ? undefined : 105 }}
                                 className={`${toolbarBtnBase} ${toolbarBtnCompact} border-red-500 text-red-600 hover:bg-red-50 hover:text-red-700`}
                                 title="Disconnect from kernel"
                             >
@@ -1757,6 +1729,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 size="sm"
                                 disabled
                                 title="Connecting..."
+                                style={{ minWidth: compactToolbar ? undefined : 105 }}
                                 className={`${toolbarBtnBase} ${toolbarBtnCompact}`}
                             >
                                 <Loader2 className="size-3 animate-spin" />
@@ -1767,6 +1740,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 variant="outline"
                                 size="sm"
                                 disabled
+                                style={{ minWidth: compactToolbar ? undefined : 105 }}
                                 className={`${toolbarBtnBase} ${toolbarBtnCompact} border-amber-500 text-amber-600`}
                                 title={podMessage || 'Waiting for previous pod to shut down…'}
                             >
@@ -1778,6 +1752,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 variant="outline"
                                 size="sm"
                                 onClick={handleConnect}
+                                style={{ minWidth: compactToolbar ? undefined : 105 }}
                                 className={`${toolbarBtnBase} ${toolbarBtnCompact} border-blue-500 text-blue-600 hover:bg-blue-50 hover:text-blue-700`}
                                 title="Connect to kernel"
                             >
@@ -1854,6 +1829,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                             <CellEditor
                                                 cell={cell}
                                                 isRunning={runningCells.has(cell.id)}
+                                                executionStartedAtMs={runningCellStarts[cell.id]}
                                                 isPending={pendingCells.has(cell.id)}
                                                 kernelBusy={sparkInitPending || runningCells.has('init-spark-context')}
                                                 // Raw kernel exec_count — same as standard Jupyter. May start at
@@ -2133,38 +2109,6 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                         </AlertDialogAction>
                         <AlertDialogAction className="bg-amber-500 text-white hover:bg-amber-600" onClick={confirmDisconnect}>
                             Disconnect
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
-
-            <AlertDialog open={pendingNavUrl !== null} onOpenChange={(open) => { if (!open) setPendingNavUrl(null); }}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Cell is still running</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Leaving this notebook will interrupt the running cell on the kernel.
-                            <br /><br />
-                            <strong>Continue</strong> — interrupt the cell and switch.
-                            <br />
-                            <strong>Cancel</strong> — stay here.
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            className="bg-amber-500 text-white hover:bg-amber-600"
-                            onClick={async () => {
-                                const target = pendingNavUrl;
-                                setPendingNavUrl(null);
-                                if (!target) return;
-                                try {
-                                    await axios.post(`/api/v1/notebooks/${notebookId}/kernel/interrupt`);
-                                } catch { /* best effort; navigate anyway */ }
-                                navigate(target);
-                            }}
-                        >
-                            Continue
                         </AlertDialogAction>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/frontend/src/components/Notebooks/SidebarFiles.tsx
+++ b/frontend/src/components/Notebooks/SidebarFiles.tsx
@@ -219,14 +219,19 @@ export const SidebarFiles: React.FC = () => {
                 </Button>
             </div>
 
-            {/* Breadcrumb */}
+            {/* Breadcrumb — fixed row height so the panel doesn't grow
+                when navigating into a folder (the back arrow only renders
+                in subfolders; without a reserved slot the row would
+                stretch when it appears). */}
             <div className="px-2 py-1.5 bg-muted/30 border-b border-border">
-                <div className="flex items-center gap-1 text-xs overflow-hidden text-nowrap">
+                <div className="flex items-center gap-1 text-xs overflow-hidden text-nowrap h-5">
                     {currentPath ? (
                         <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0 -ml-1" onClick={navigateUp} title="Go Up">
                             <ChevronLeft className="size-3.5" />
                         </Button>
-                    ) : null}
+                    ) : (
+                        <span className="w-5 shrink-0 -ml-1" aria-hidden />
+                    )}
                     <span className="truncate font-mono text-[10px] flex-1" title={'/' + currentPath}>
                         /{currentPath}
                     </span>
@@ -261,22 +266,26 @@ export const SidebarFiles: React.FC = () => {
                         </div>
                     )}
                     {files.map((file) => (
-                        <div key={file.key} className="group flex items-center gap-2 p-1.5 rounded hover:bg-muted/50 transition-colors">
+                        <div key={file.key} className="group flex items-center gap-2 p-1.5 rounded hover:bg-muted/50 transition-colors h-7">
                             {file.is_folder ? (
                                 <FolderOpen className="size-3.5 text-yellow-500 shrink-0" />
                             ) : (
                                 <FileText className="size-3.5 text-blue-500 shrink-0" />
                             )}
-                            <div className="flex-1 min-w-0 overflow-hidden">
+                            {/* Single-line row so swapping a folder ↔ file at
+                                the same position doesn't change the row
+                                height. File size moves inline to the right
+                                instead of stacking under the name. */}
+                            <div className="flex-1 min-w-0 overflow-hidden flex items-baseline gap-2">
                                 {file.is_folder ? (
-                                    <div onClick={() => navigateToFolder(file)} className="font-medium cursor-pointer truncate hover:text-primary transition-colors text-[11px]">
+                                    <span onClick={() => navigateToFolder(file)} className="font-medium cursor-pointer truncate hover:text-primary transition-colors text-[11px] flex-1">
                                         {file.name}
-                                    </div>
+                                    </span>
                                 ) : (
-                                    <div className="truncate text-[11px]" title={file.name}>{file.name}</div>
+                                    <span className="truncate text-[11px] flex-1" title={file.name}>{file.name}</span>
                                 )}
                                 {!file.is_folder && (
-                                    <div className="text-[9px] text-muted-foreground">{formatFileSize(file.size)}</div>
+                                    <span className="text-[9px] text-muted-foreground shrink-0">{formatFileSize(file.size)}</span>
                                 )}
                             </div>
                             <div className="flex opacity-0 group-hover:opacity-100 transition-opacity gap-0.5">

--- a/frontend/src/components/Notebooks/SidebarFiles.tsx
+++ b/frontend/src/components/Notebooks/SidebarFiles.tsx
@@ -222,19 +222,31 @@ export const SidebarFiles: React.FC = () => {
             {/* Breadcrumb — fixed row height so the panel doesn't grow
                 when navigating into a folder (the back arrow only renders
                 in subfolders; without a reserved slot the row would
-                stretch when it appears). */}
-            <div className="px-2 py-1.5 bg-muted/30 border-b border-border">
-                <div className="flex items-center gap-1 text-xs overflow-hidden text-nowrap h-5">
-                    {currentPath ? (
-                        <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0 -ml-1" onClick={navigateUp} title="Go Up">
-                            <ChevronLeft className="size-3.5" />
-                        </Button>
-                    ) : (
-                        <span className="w-5 shrink-0 -ml-1" aria-hidden />
-                    )}
-                    <span className="truncate font-mono text-[10px] flex-1" title={'/' + currentPath}>
-                        /{currentPath}
-                    </span>
+                stretch when it appears). Scope prefix is stripped from
+                the displayed path since the scope is already indicated
+                by the tabs above. */}
+            <div className="px-2 py-1 bg-muted/30 border-b border-border">
+                <div className="flex items-center text-xs overflow-hidden text-nowrap h-5">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5 shrink-0 -ml-1 disabled:opacity-40"
+                        onClick={navigateUp}
+                        disabled={!currentPath}
+                        title="Go Up"
+                    >
+                        <ChevronLeft className="size-3.5" />
+                    </Button>
+                    {(() => {
+                        const stripped = currentPath.startsWith(activeScope + '/')
+                            ? currentPath.slice(activeScope.length + 1)
+                            : currentPath;
+                        return (
+                            <span className="truncate font-mono text-[10px] flex-1" title={'/' + stripped}>
+                                /{stripped}
+                            </span>
+                        );
+                    })()}
                     <button
                         onClick={() => copyPath(buildFullPath(currentPath))}
                         className="p-0.5 hover:bg-muted rounded text-muted-foreground hover:text-foreground shrink-0"

--- a/frontend/src/components/Notebooks/parts/CellEditor.tsx
+++ b/frontend/src/components/Notebooks/parts/CellEditor.tsx
@@ -29,6 +29,12 @@ interface CellEditorProps {
     cell: NotebookCell;
     isRunning: boolean;
     isPending?: boolean;  // Cell is queued for execution (Run All)
+    // Original execute_request startedAt (epoch ms). Set when the
+    // running state was restored from the backend recorder so the
+    // timer continues from the real start instead of resetting to 0
+    // on every page reload. Undefined for cells started in this tab
+    // (timer falls back to Date.now()).
+    executionStartedAtMs?: number;
     kernelBusy?: boolean;  // Kernel unavailable (e.g. Spark booting) — disable Play silently
     executionCount?: number;  // In [N]:
     hasExecuted: boolean;
@@ -49,6 +55,7 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
     isRunning,
     readOnly,
     isPending,
+    executionStartedAtMs,
     kernelBusy,
     executionCount,
     hasExecuted,
@@ -91,13 +98,13 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
             setElapsedSeconds(0);
             return;
         }
-        const startedAt = Date.now();
-        setElapsedSeconds(0);
+        const startedAt = executionStartedAtMs ?? Date.now();
+        setElapsedSeconds((Date.now() - startedAt) / 1000);
         const id = setInterval(() => {
             setElapsedSeconds((Date.now() - startedAt) / 1000);
         }, 100);
         return () => clearInterval(id);
-    }, [isRunning]);
+    }, [isRunning, executionStartedAtMs]);
 
     // Local source state to prevent cursor jumping on parent re-render
     const [localSource, setLocalSource] = useState(cell.source || '');
@@ -368,6 +375,7 @@ export const CellEditor: React.FC<CellEditorProps> = React.memo(({
         prevProps.cell.source === nextProps.cell.source &&
         prevProps.cell.type === nextProps.cell.type &&
         prevProps.isRunning === nextProps.isRunning &&
+        prevProps.executionStartedAtMs === nextProps.executionStartedAtMs &&
         prevProps.isPending === nextProps.isPending &&
         prevProps.kernelBusy === nextProps.kernelBusy &&
         prevProps.hasExecuted === nextProps.hasExecuted &&

--- a/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
@@ -34,7 +34,14 @@ export const ConnectionStatusBadge: React.FC<{
             ) : (
                 <Circle className={`h-3 w-3 ${config.color} fill-current`} />
             )}
-            {!compact && <span className="text-sm text-muted-foreground whitespace-nowrap">{config.label}</span>}
+            {!compact && (
+                // Fixed width sized to the longest label ("Disconnecting…" /
+                // "Booting Spark…") so toolbar items to the right don't
+                // shift when the status changes.
+                <span className="text-sm text-muted-foreground whitespace-nowrap inline-block w-32">
+                    {config.label}
+                </span>
+            )}
         </div>
     );
 };

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -227,6 +227,32 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 sessionManager.updateSession(notebookId, { status: 'connected', podPhase: '', podMessage: '' });
             }
 
+            // status:busy on iopub tells us THIS msg_id just started
+            // executing on the kernel. For Run All this is what
+            // promotes a queued cell into runningCells — until busy
+            // fires the cell is sitting in the kernel's FIFO queue,
+            // not actually executing.
+            if (executionState === 'busy' && parentMsgId) {
+                const pending = session.pendingExecutions.get(parentMsgId);
+                if (pending?.cellId) {
+                    const cur = sessionManager.getSession(notebookId);
+                    if (cur.pendingCells.has(pending.cellId)) {
+                        const np = new Set(cur.pendingCells);
+                        np.delete(pending.cellId);
+                        const nr = new Set(cur.runningCells);
+                        nr.add(pending.cellId);
+                        // Reset startedAt to "kernel actually started"
+                        // so the timer reflects real execution time, not
+                        // the time spent waiting in the kernel queue.
+                        pending.startedAt = Date.now();
+                        sessionManager.updateSession(notebookId, {
+                            pendingCells: np,
+                            runningCells: nr,
+                        });
+                    }
+                }
+            }
+
             // status:idle on iopub is the broadcast completion signal for
             // an execute_request. We get this even after a tab reload
             // (unlike execute_reply which is shell-channel point-to-point
@@ -503,24 +529,44 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         // is still executing across a tab reload.
         try {
             const resp = await axios.get(`/api/v1/notebooks/${notebookId}/kernel/active-executions`);
-            const execs: Array<{ msg_id: string; cell_id: string; started_at: string; execution_count: number; has_error: boolean }>
-                = resp.data?.executions || [];
+            const execs: Array<{
+                msg_id: string;
+                cell_id: string;
+                started_at: string;
+                kernel_started_at?: string;
+                execution_count: number;
+            }> = resp.data?.executions || [];
             if (execs.length > 0) {
                 const session = sessionManager.getSession(notebookId);
                 const newRunning = new Set(session.runningCells);
+                const newPending = new Set(session.pendingCells);
+                const newCounts = { ...session.executionCounts };
                 for (const e of execs) {
                     if (!e.msg_id || !e.cell_id) continue;
                     if (session.pendingExecutions.has(e.msg_id)) continue;
-                    const startedAt = e.started_at ? new Date(e.started_at).getTime() : Date.now();
+                    const isRunning = !!e.kernel_started_at;
+                    const startedAt = isRunning
+                        ? new Date(e.kernel_started_at!).getTime()
+                        : (e.started_at ? new Date(e.started_at).getTime() : Date.now());
                     session.pendingExecutions.set(e.msg_id, {
                         cellId: e.cell_id,
-                        hadError: !!e.has_error,
                         startedAt,
                         resolve: () => { /* restored entry has no caller waiting */ },
                     });
-                    newRunning.add(e.cell_id);
+                    if (isRunning) {
+                        newRunning.add(e.cell_id);
+                    } else {
+                        newPending.add(e.cell_id);
+                    }
+                    if (e.execution_count > 0) {
+                        newCounts[e.cell_id] = e.execution_count;
+                    }
                 }
-                sessionManager.updateSession(notebookId, { runningCells: newRunning });
+                sessionManager.updateSession(notebookId, {
+                    runningCells: newRunning,
+                    pendingCells: newPending,
+                    executionCounts: newCounts,
+                });
                 devLog(`[JupyterKernel][${notebookId}] Restored ${execs.length} active execution(s) from backend recorder`);
             }
         } catch (e) {
@@ -1046,7 +1092,7 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         cellId: string,
         code: string,
         onComplete?: (error?: boolean) => void,
-        options?: { silent?: boolean; storeHistory?: boolean }
+        options?: { silent?: boolean; storeHistory?: boolean; queued?: boolean }
     ) => {
         const session = sessionManager.getSession(notebookId);
         const ws = session.ws;
@@ -1059,20 +1105,19 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             return;
         }
 
-        // Kernel has a single execution slot — clicking Run on cell B while
-        // cell A is still running would (a) queue B on the kernel side and
-        // (b) make the frontend mark both as 'running'. Then a Stop on
-        // either cell sends one SIGINT that cancels whichever the kernel
-        // happens to be executing, looking to the user like "stopping one
-        // cell also stopped the other". Refuse the second click instead.
-        // Run All has its own queue (executeAllCells chains via onComplete)
-        // and is not affected.
-        const otherRunning = [...session.runningCells].filter(id => id !== cellId);
-        if (otherRunning.length > 0) {
-            toast.warning('Kernel is busy', {
-                description: 'Another cell is running. Wait for it to finish or click Stop on it first.',
-            });
-            return;
+        // Single-click Run on a second cell while another is running is
+        // ambiguous — Stop sends one SIGINT and we can't tell which cell
+        // the user meant to stop. Refuse, unless this call is part of an
+        // intentional batch (Run All) where queueing on the kernel side
+        // is the whole point.
+        if (!options?.queued) {
+            const otherRunning = [...session.runningCells].filter(id => id !== cellId);
+            if (otherRunning.length > 0) {
+                toast.warning('Kernel is busy', {
+                    description: 'Another cell is running. Wait for it to finish or click Stop on it first.',
+                });
+                return;
+            }
         }
 
         // Policy Check: Skip for system-generated cells and exam mode (kernel proxy).
@@ -1115,11 +1160,19 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
 
         devLog(`[JupyterKernel][${notebookId}] Executing cell ${cellId}`, options?.silent ? '(silent)' : '');
 
-        // Clear previous output and remove from pending (if was queued)
+        // Clear previous output. For a queued batch (Run All) the cell
+        // goes into pendingCells until iopub status:busy promotes it to
+        // running; for a direct Run it goes straight to runningCells.
         const newOutputs = { ...session.outputs, [cellId]: [] };
-        const newRunningCells = new Set(session.runningCells).add(cellId);
+        const newRunningCells = new Set(session.runningCells);
         const newPendingCells = new Set(session.pendingCells);
-        newPendingCells.delete(cellId);
+        if (options?.queued) {
+            newPendingCells.add(cellId);
+            newRunningCells.delete(cellId);
+        } else {
+            newRunningCells.add(cellId);
+            newPendingCells.delete(cellId);
+        }
 
         sessionManager.updateSession(notebookId, {
             outputs: newOutputs,
@@ -1190,42 +1243,22 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             return;
         }
 
-        // Filter only code cells
         const codeCells = cells.filter(c => c.type === 'code');
         if (codeCells.length === 0) return;
 
-        devLog(`[JupyterKernel][${notebookId}] Run All: ${codeCells.length} cells`);
+        devLog(`[JupyterKernel][${notebookId}] Run All: ${codeCells.length} cells (queueing all upfront)`);
 
-        // Mark all cells as pending (except first which will run immediately)
-        const pendingCellIds = new Set(codeCells.slice(1).map(c => c.id));
-        sessionManager.updateSession(notebookId, { pendingCells: pendingCellIds });
-
-        // Execute cells sequentially using onComplete callback chain
-        let cellIndex = 0;
-
-        const executeNext = (error?: boolean) => {
-            if (error) {
-                const remaining = codeCells.length - cellIndex;
-                sessionManager.updateSession(notebookId, { pendingCells: new Set() });
-                toast.error(remaining > 0
-                    ? `Run All stopped: ${remaining} cell(s) skipped due to error`
-                    : 'Run All completed with error');
-                return;
-            }
-            if (cellIndex >= codeCells.length) {
-                devLog(`[JupyterKernel][${notebookId}] Run All complete`);
-                return;
-            }
-
-            const cell = codeCells[cellIndex];
-            cellIndex++;
-
-            executeCell(cell.id, cell.code, executeNext);
-        };
-
-        // Start with first cell
-        executeNext();
-
+        // Send every execute_request to the kernel immediately. Jupyter
+        // kernels process them FIFO and honor stop_on_error so a failure
+        // aborts the rest server-side — meaning a tab close mid-batch no
+        // longer halts the run (the kernel finishes the queue on its
+        // own, recorder captures output, next page load restores it).
+        codeCells.forEach((cell, idx) => {
+            // First cell goes straight to runningCells; the rest sit in
+            // pendingCells until iopub status:busy promotes each one as
+            // the kernel actually picks it up.
+            executeCell(cell.id, cell.code, undefined, { queued: idx > 0 });
+        });
     }, [notebookId, executeCell]);
 
     // Clear all pending cells (for canceling Run All)

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -226,6 +226,36 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 // show "Connected" cleanly.
                 sessionManager.updateSession(notebookId, { status: 'connected', podPhase: '', podMessage: '' });
             }
+
+            // status:idle on iopub is the broadcast completion signal for
+            // an execute_request. We get this even after a tab reload
+            // (unlike execute_reply which is shell-channel point-to-point
+            // and only goes to the originating session). If we still have
+            // a pendingExecutions entry for the parent msg_id — i.e. the
+            // shell-channel cleanup hasn't already fired — clean up the
+            // cell's running state here.
+            if (executionState === 'idle' && parentMsgId) {
+                const pending = session.pendingExecutions.get(parentMsgId);
+                if (pending?.cellId) {
+                    const cur = sessionManager.getSession(notebookId);
+                    if (cur.runningCells.has(pending.cellId)) {
+                        const next = new Set(cur.runningCells);
+                        next.delete(pending.cellId);
+                        const execTimes = { ...cur.executionTimes };
+                        if (pending.startedAt) {
+                            execTimes[pending.cellId] = Date.now() - pending.startedAt;
+                        }
+                        const executed = new Set(cur.executedCells);
+                        executed.add(pending.cellId);
+                        sessionManager.updateSession(notebookId, {
+                            runningCells: next,
+                            executionTimes: execTimes,
+                            executedCells: executed,
+                        });
+                    }
+                    setTimeout(() => session.pendingExecutions.delete(parentMsgId), 5000);
+                }
+            }
             return;
         }
 
@@ -464,7 +494,40 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
     }, [notebookId]);
 
     // Setup WebSocket connection
-    const setupWebSocket = useCallback((kernelId: string) => {
+    const setupWebSocket = useCallback(async (kernelId: string) => {
+        // Restore any in-flight executions from the backend recorder
+        // BEFORE the WS opens. This populates pendingExecutions +
+        // runningCells so the FIRST iopub message that lands has a
+        // parent_msg_id we can look up, and so the badge shows
+        // "running" with the correct startedAt for cells the kernel
+        // is still executing across a tab reload.
+        try {
+            const resp = await axios.get(`/api/v1/notebooks/${notebookId}/kernel/active-executions`);
+            const execs: Array<{ msg_id: string; cell_id: string; started_at: string; execution_count: number; has_error: boolean }>
+                = resp.data?.executions || [];
+            if (execs.length > 0) {
+                const session = sessionManager.getSession(notebookId);
+                const newRunning = new Set(session.runningCells);
+                for (const e of execs) {
+                    if (!e.msg_id || !e.cell_id) continue;
+                    if (session.pendingExecutions.has(e.msg_id)) continue;
+                    const startedAt = e.started_at ? new Date(e.started_at).getTime() : Date.now();
+                    session.pendingExecutions.set(e.msg_id, {
+                        cellId: e.cell_id,
+                        hadError: !!e.has_error,
+                        startedAt,
+                        resolve: () => { /* restored entry has no caller waiting */ },
+                    });
+                    newRunning.add(e.cell_id);
+                }
+                sessionManager.updateSession(notebookId, { runningCells: newRunning });
+                devLog(`[JupyterKernel][${notebookId}] Restored ${execs.length} active execution(s) from backend recorder`);
+            }
+        } catch (e) {
+            // Endpoint may not exist on older backends — non-fatal.
+            devLog(`[JupyterKernel][${notebookId}] active-executions fetch failed:`, e);
+        }
+
         const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         const wsHost = import.meta.env.VITE_BACKEND_WS_URL || `${wsProtocol}//${window.location.host}`;
 
@@ -1080,7 +1143,12 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 version: '5.3'
             },
             parent_header: {},
-            metadata: {},
+            // sparklabx_cell_id lets the backend KernelRecorder tag
+            // iopub messages from this execution with the originating
+            // cell so output can be persisted to cells.last_output
+            // even after the browser tab closes. Jupyter ignores
+            // unknown metadata fields.
+            metadata: { sparklabx_cell_id: cellId },
             content: {
                 code,
                 silent: options?.silent ?? false,
@@ -1390,6 +1458,17 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         });
     }, [notebookId]);
 
+    // cellId → original execute_request startedAt (epoch ms). Lets
+    // the live timer in CellEditor keep ticking from the real start
+    // even after a tab reload (state restored from the backend
+    // recorder includes the original startedAt).
+    const runningCellStarts: Record<string, number> = {};
+    session.pendingExecutions.forEach(p => {
+        if (p.cellId && session.runningCells.has(p.cellId)) {
+            runningCellStarts[p.cellId] = p.startedAt;
+        }
+    });
+
     return {
         connectionStatus: session.status,
         deadReason: session.deadReason,  // Reason for kernel death (when status is 'dead')
@@ -1397,6 +1476,7 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
         podMessage: session.podMessage,  // human-readable phase message
         cellOutputs: session.outputs,
         runningCells: session.runningCells,
+        runningCellStarts,
         pendingCells: session.pendingCells,
         executionCounts: session.executionCounts,
         executionTimes: session.executionTimes,


### PR DESCRIPTION
## Summary

Adds a per-kernel singleton recorder service (`services/kernel_recorder.go`) that maintains its own WebSocket to Jupyter Kernel Gateway, **independent of any client**. It captures every iopub message, attributes it to a cell via the \`msg_id → cell_id\` mapping registered by the per-client WS proxy on \`execute_request\`, and persists output to \`notebook_cells.last_output\` with a 500 ms debounce.

This is the foundation for the **"tab close / reload preserves running cell"** UX — Databricks-like, instead of dropping in-flight output into the void when the user's WS closes.

### Why iopub status:idle, not execute_reply

\`execute_reply\` travels on the **shell channel** point-to-point to the originating session. Our recorder opens its own WS session, so it never sees the shell reply. \`status: idle\` on iopub is **broadcast** and reaches every subscriber — the only reliable completion signal for an out-of-session observer.

The same trick fixes a related frontend bug: after a tab reload, the new WS isn't the original session either, so clicking Interrupt fired KeyboardInterrupt on the kernel but \`runningCells\` never cleared (no \`execute_reply\` arrived). \`handleKernelMessage\` now cleans up on iopub \`status: idle\` too.

### Frontend wiring

- \`executeCell\` stamps \`metadata.sparklabx_cell_id\` in \`execute_request\` so the recorder can tag iopub by cell.
- \`useJupyterKernel.setupWebSocket\` calls \`GET /kernel/active-executions\` **before** opening the WS, populates \`pendingExecutions\` + \`runningCells\` + \`runningCellStarts\` — so a reload restores the running state with the original \`startedAt\` and the timer keeps ticking from the real start.
- \`CellEditor\` accepts \`executionStartedAtMs\` prop; falls back to \`Date.now()\` for cells started in this tab.

### Dropped (replaced by the recorder)

- \`beforeunload\` warning prompt for unsaved cells
- \`pagehide\` keepalive fetch to \`/kernel/interrupt\` with \`clear_cells\`
- \`AlertDialog\` "Cell is still running" on in-app navigation
- \`guardedNavigate\` wrapper

Output persists regardless of client state now; nothing needs to be interrupted on leave.

### Toolbar polish (bonus)

- Language badge: fixed-width text span so Python ↔ Scala doesn't shift items to its right.
- ConnectionStatusBadge: fixed-width label so Connected / Disconnecting… / Booting Spark… don't shift either.
- Connect/Disconnect button: \`minWidth: 105\` so all four states (Connect / Disconnect / Connecting… / Shutting down…) line up.
- Notebook name input: \`w-56\`/\`w-32 shrink-0\` so switching notebooks doesn't reflow the toolbar.

## Test plan

- [ ] Run a cell with \`Thread.sleep(10000); println(\"done\")\` → close tab → wait 15s → reopen → cell shows \`In [N]\` with full \"done\" output (recorder persisted to DB).
- [ ] Run a long cell → reload tab mid-execution → cell shows \"Running\" with timer continuing from real start time (not reset to 0).
- [ ] Run two cells (one fast \`spark\`, one slow heavy job) → reload during slow cell → fast cell shows completed, slow cell shows running. (Previously both showed \`In [*]\` because recorder didn't see \`execute_reply\`.)
- [ ] After reload, click Interrupt → cell stops, badge turns red XCircle, timer freezes.
- [ ] Switch between Python and Scala notebook → all toolbar items right of language badge stay put.
- [ ] Connect → Connected → Disconnect → Disconnecting… → Disconnected → button width stays at 105 px throughout.