### PR TITLE
fix(security): enforce per-user notebook ownership; harden KERNEL_MODE

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -79,6 +79,7 @@ func main() {
 	// KernelGateway: shared single container OR per-user pod via KERNEL_MODE.
 	kernelGateway, err := services.NewKernelGateway(services.KernelGatewaySettings{
 		Mode:              cfg.KernelMode,
+		Environment:       cfg.Environment,
 		JupyterGatewayURL: cfg.JupyterGatewayURL,
 		PodImage:          cfg.KernelPodImage,
 		PodNamespace:      cfg.KernelPodNamespace,

--- a/backend/internal/handlers/notebooks.go
+++ b/backend/internal/handlers/notebooks.go
@@ -33,12 +33,12 @@ func getOwner(c *gin.Context) (string, string) {
 }
 
 // checkNotebookReadAccess verifies the caller can read the notebook.
-// Admins can read all notebooks. Students can read their own notebooks and public notebooks.
+// Every user (including admins) may read only their OWN notebooks, plus any
+// notebook explicitly marked public. There is intentionally no admin override:
+// a notebook is a private workspace, consistent with the per-user object-store
+// isolation. If a support/admin "read any" tier is ever needed, gate it on the
+// superadmin role here — do NOT widen it to all admins.
 func checkNotebookReadAccess(c *gin.Context, notebookID string) bool {
-	role, _ := c.Get("role")
-	if role != "student" {
-		return true
-	}
 	ownerID, _ := getOwner(c)
 	db := database.GetDB()
 	var nbOwnerID string
@@ -54,13 +54,10 @@ func checkNotebookReadAccess(c *gin.Context, notebookID string) bool {
 	return true
 }
 
-// checkNotebookWriteAccess verifies the caller can modify or execute against the notebook.
-// Admins can write all notebooks. Students can write only their own notebooks.
+// checkNotebookWriteAccess verifies the caller can modify or execute against the
+// notebook. Only the owner may write — public notebooks are read-only to
+// non-owners. No admin override (see checkNotebookReadAccess).
 func checkNotebookWriteAccess(c *gin.Context, notebookID string) bool {
-	role, _ := c.Get("role")
-	if role != "student" {
-		return true
-	}
 	ownerID, _ := getOwner(c)
 	db := database.GetDB()
 	var nbOwnerID string
@@ -223,13 +220,13 @@ func (h *NotebookHandler) GetNotebook(c *gin.Context) {
 	}
 
 	// Inline access check — we already fetched owner_id/is_public above, so skip
-	// the redundant query that checkNotebookReadAccess() would make.
-	if role, _ := c.Get("role"); role == "student" {
-		callerID, _ := getOwner(c)
-		if nb.OwnerID != callerID && !nb.IsPublic {
-			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
-			return
-		}
+	// the redundant query that checkNotebookReadAccess() would make. Same rule:
+	// owner-only, plus public notebooks. Applies to every caller (no admin
+	// override) so one user can't read another's notebook by id.
+	callerID, _ := getOwner(c)
+	if nb.OwnerID != callerID && !nb.IsPublic {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		return
 	}
 
 	// Fetch cells

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -87,6 +87,7 @@ func (s *SharedGateway) EnsureSpawning(_ string) error { return nil }
 // the config package.
 type KernelGatewaySettings struct {
 	Mode              string        // "shared" | "docker_per_user" | "k8s_per_user"
+	Environment       string        // "production" | other — gates the shared-mode safety check
 	JupyterGatewayURL string        // only used in shared mode
 	PodImage          string        // kernel container/pod image
 	PodNamespace      string        // K8s namespace (k8s_per_user)
@@ -115,13 +116,26 @@ type KernelGatewaySettings struct {
 //                        Backend must run in-cluster with the RBAC in kubernetes/.
 func NewKernelGateway(s KernelGatewaySettings) (KernelGateway, error) {
 	mode := s.Mode
+	explicit := mode != ""
 	if mode == "" {
 		mode = "shared"
 	}
 
 	switch mode {
 	case "shared":
-		log.Info().Str("gateway", s.JupyterGatewayURL).Msg("kernel gateway: shared mode (no isolation)")
+		// Shared mode = one Jupyter Gateway for everyone, zero per-user
+		// isolation: any user's kernel can reach any other user's in-memory
+		// state and (without per-user MinIO IAM) their object-store data.
+		// Refuse to start this way in production — losing isolation must be a
+		// loud, deliberate choice, never a silent default.
+		if s.Environment == "production" {
+			return nil, fmt.Errorf("KERNEL_MODE=shared is unsafe in production (no per-user kernel isolation); set KERNEL_MODE=docker_per_user or k8s_per_user")
+		}
+		if explicit {
+			log.Warn().Str("gateway", s.JupyterGatewayURL).Msg("kernel gateway: SHARED mode — NO per-user isolation, all users share one kernel container (dev only)")
+		} else {
+			log.Warn().Str("gateway", s.JupyterGatewayURL).Msg("kernel gateway: KERNEL_MODE not set, defaulting to SHARED — NO per-user isolation (set docker_per_user/k8s_per_user for multi-user)")
+		}
 		return NewSharedGateway(s.JupyterGatewayURL), nil
 	case "docker_per_user":
 		gw, err := NewDockerPerUserGateway(DockerPerUserConfig{


### PR DESCRIPTION
## Summary

Fixes a **broken access control (IDOR)** vulnerability: any authenticated user could read, modify, delete, export, or run **any other user's notebook** (including cell code + outputs) by notebook id.

### Root cause
This app was refactored from an exam platform that had a `student` role. After the refactor, every OAuth user is created as an `admin`, but the notebook access checks still short-circuited with:

```go
if role != "student" { return true }   // → every user passes
```

So the owner check never ran for anyone. The UI masked it (`ListNotebooks` is owner-scoped, so you don't *see* others' notebooks), but the per-id REST endpoints — `GET/PUT/DELETE /notebooks/:id`, cells, reorder, export, kernel connect/ws — had no real ownership enforcement. Knowing/guessing a notebook UUID was enough.

### Fix
- `checkNotebookReadAccess` / `checkNotebookWriteAccess` now enforce `owner == caller` for **all** roles. Public notebooks stay world-readable, owner-only writable. **No admin override** — a notebook is a private workspace, consistent with the existing per-user MinIO IAM object-store isolation. (If a support 'read any' tier is ever needed, gate it explicitly on `superadmin` here — don't widen to all admins.)
- `GetNotebook` had a separate inline check that only applied to students; now applies the owner rule to every caller.
- All write / cell / reorder / export / kernel-connect / ws handlers already route through these two functions, so they're fixed transitively.

### KERNEL_MODE hardening (defense-in-depth)
`shared` mode runs one Jupyter Gateway for everyone (no per-user kernel isolation — a known second exposure path). Now:
- **Refused at startup** when `ENVIRONMENT=production`.
- Loud warning otherwise, plus a distinct warning when `KERNEL_MODE` is unset and silently defaulting to `shared`.

## Test plan (verified on docker-compose.test.yml, two real users)
| # | Action | Expect | Result |
|---|--------|--------|--------|
| 1 | user B GET user A's notebook | 403 | ✅ |
| 2 | user B GET own notebook | 200 | ✅ |
| 3 | user A GET own notebook | 200 | ✅ |
| 4 | user B DELETE A's notebook | 403 | ✅ |
| 5 | user B PUT A's notebook | 403 | ✅ |
| 6 | user A list notebooks | own scope only | ✅ |
| 7 | owner PUT own notebook | 200 (not over-blocked) | ✅ |
| 8 | user B PUT a cell in A's notebook | 403 | ✅ |
| 9 | user B export A's notebook HTML | 403 | ✅ |

A's cell data confirmed untouched after the blocked writes. `go build` + `go vet` clean.

## Notes
- Independent of #64 (frontend-only).
- If admin UIs ever need to inspect another user's notebook for support, that should be a separate, explicit, audited feature — not a blanket admin override.