### PR TITLE
fix(chart): expose MINIO_ACCESS_KEY/SECRET_KEY to backend

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -42,6 +42,12 @@ stringData:
   SEED_ADMIN_PASSWORD: {{ .Values.secrets.seedAdmin.password | quote }}
   MINIO_ROOT_USER: {{ .Values.secrets.minio.rootUser | quote }}
   MINIO_ROOT_PASSWORD: {{ .Values.secrets.minio.rootPassword | quote }}
+  {{/* Backend reads MINIO_ACCESS_KEY/MINIO_SECRET_KEY (see config.go); the
+       MinIO server uses MINIO_ROOT_USER/PASSWORD. They're the same credential
+       under different env names — expose both so the backend's MinIO IAM
+       initializes instead of reporting "MinIO is not configured". */}}
+  MINIO_ACCESS_KEY: {{ .Values.secrets.minio.rootUser | quote }}
+  MINIO_SECRET_KEY: {{ .Values.secrets.minio.rootPassword | quote }}
   GOOGLE_CLIENT_ID: {{ .Values.secrets.google.clientId | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.secrets.google.clientSecret | quote }}
   MICROSOFT_CLIENT_ID: {{ .Values.secrets.microsoft.clientId | quote }}


### PR DESCRIPTION
## Problem
Backend on Kubernetes reported **"MinIO is not configured"** — all storage features and per-user object-store isolation disabled.

## Root cause
Env name mismatch in the Helm chart Secret:
- Backend reads `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` ([config.go](backend/internal/config/config.go))
- Chart only provided `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` (the names the MinIO **server** consumes)

Same credential, different env names → backend saw empty creds → `NewMinIOIAM` returned nil.

(docker-compose already used the correct `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY`, which is why it only surfaced on the k8s/Helm path.)

## Fix
Add `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` to the chart Secret (same root credential, names the backend expects). MinIO server keeps using `MINIO_ROOT_*`.

## Verified
Fresh OrbStack k8s deploy after `helm upgrade` + backend restart:
- backend pod env now has both `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`
- `GET /notebooks/storage/path` → 200, `{"available":true,"path":"s3a://workspace/users/admin/"}`
- `GET /notebooks/storage/files` → 200
- no more "MinIO is not configured" in logs