### PR TITLE
Promote: chart MinIO env fix (#68) to main

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -42,6 +42,12 @@ stringData:
   SEED_ADMIN_PASSWORD: {{ .Values.secrets.seedAdmin.password | quote }}
   MINIO_ROOT_USER: {{ .Values.secrets.minio.rootUser | quote }}
   MINIO_ROOT_PASSWORD: {{ .Values.secrets.minio.rootPassword | quote }}
+  {{/* Backend reads MINIO_ACCESS_KEY/MINIO_SECRET_KEY (see config.go); the
+       MinIO server uses MINIO_ROOT_USER/PASSWORD. They're the same credential
+       under different env names — expose both so the backend's MinIO IAM
+       initializes instead of reporting "MinIO is not configured". */}}
+  MINIO_ACCESS_KEY: {{ .Values.secrets.minio.rootUser | quote }}
+  MINIO_SECRET_KEY: {{ .Values.secrets.minio.rootPassword | quote }}
   GOOGLE_CLIENT_ID: {{ .Values.secrets.google.clientId | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.secrets.google.clientSecret | quote }}
   MICROSOFT_CLIENT_ID: {{ .Values.secrets.microsoft.clientId | quote }}


### PR DESCRIPTION
Promotes the MinIO env-name fix from test → main.

- fix(chart): expose MINIO_ACCESS_KEY/SECRET_KEY to backend so MinIO IAM initializes (was 'MinIO is not configured' on k8s/Helm deploys).

Already on main: #64 (frontend perf), #65 (notebook owner isolation + KERNEL_MODE hardening). This adds the chart-only fix. Verified on OrbStack k8s.