### PR TITLE
feat: live kernel CPU/RAM usage widget (docker + k8s)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -222,6 +222,7 @@ func main() {
 		kernelMeta.Use(middleware.RequireAdmin(cfg))
 		{
 			kernelMeta.GET("/spawn-status", localKernelHandler.SpawnStatus)
+			kernelMeta.GET("/usage", localKernelHandler.Usage)
 		}
 	}
 

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -112,6 +112,8 @@ func (h *LocalKernelHandler) Usage(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"available":       true,
 		"cpu_percent":     u.CPUPercent,
+		"cpu_used_cores":  u.CPUUsedCores,
+		"cpu_limit_cores": u.CPULimitCores,
 		"mem_used_bytes":  u.MemUsedBytes,
 		"mem_limit_bytes": u.MemLimitBytes,
 	})

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -90,6 +90,33 @@ func (h *LocalKernelHandler) SpawnStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, st)
 }
 
+// Usage returns the live CPU/memory usage of the caller's kernel container.
+// available=false means there's nothing to show (shared mode, no container
+// yet, or metrics unavailable) — the FE hides the widget in that case rather
+// than surfacing an error.
+func (h *LocalKernelHandler) Usage(c *gin.Context) {
+	userID := userIDString(c)
+	if userID == "" {
+		c.JSON(http.StatusOK, gin.H{"available": false})
+		return
+	}
+	// Short timeout: the Docker stats call is ~1s; never block the FE poll.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	defer cancel()
+	u, err := h.gateway.Usage(ctx, userID)
+	if err != nil {
+		// ErrUsageUnsupported (and any transient failure) → unavailable, not 500.
+		c.JSON(http.StatusOK, gin.H{"available": false})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"available":       true,
+		"cpu_percent":     u.CPUPercent,
+		"mem_used_bytes":  u.MemUsedBytes,
+		"mem_limit_bytes": u.MemLimitBytes,
+	})
+}
+
 func userIDString(c *gin.Context) string {
 	if v, ok := c.Get("admin_id"); ok {
 		if s, ok := v.(string); ok && s != "" {

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -485,6 +485,8 @@ func (g *DockerPerUserGateway) Usage(ctx context.Context, userID string) (Resour
 
 	usage := ResourceUsage{
 		CPUPercent:    cpuPct,
+		CPUUsedCores:  usedCores,
+		CPULimitCores: limitCores,
 		MemUsedBytes:  memUsed,
 		MemLimitBytes: s.MemoryStats.Limit,
 	}

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -34,7 +34,20 @@ type DockerPerUserGateway struct {
 	touchMu  sync.Mutex
 	touchBuf map[string]time.Time
 	stopCh   chan struct{}
+
+	// usageCache memoizes the (slow, ~1s) Docker stats call per user so
+	// several notebook tabs polling /kernel/usage don't each hammer the
+	// daemon. Entries are served for usageTTL then refreshed on next read.
+	usageMu    sync.Mutex
+	usageCache map[string]cachedUsage
 }
+
+type cachedUsage struct {
+	usage ResourceUsage
+	at    time.Time
+}
+
+const usageTTL = 2 * time.Second
 
 type DockerPerUserConfig struct {
 	Image         string            // kernel image to run
@@ -95,10 +108,11 @@ func NewDockerPerUserGateway(cfg DockerPerUserConfig) (*DockerPerUserGateway, er
 		},
 	}
 	g := &DockerPerUserGateway{
-		cfg:      cfg,
-		httpc:    &http.Client{Transport: transport, Timeout: 30 * time.Second},
-		touchBuf: make(map[string]time.Time),
-		stopCh:   make(chan struct{}),
+		cfg:        cfg,
+		httpc:      &http.Client{Transport: transport, Timeout: 30 * time.Second},
+		touchBuf:   make(map[string]time.Time),
+		stopCh:     make(chan struct{}),
+		usageCache: make(map[string]cachedUsage),
 	}
 	log.Info().Str("image", cfg.Image).Str("network", cfg.Network).
 		Dur("idle_timeout", cfg.IdleTimeout).Msg("docker_per_user kernel gateway initialized")
@@ -374,6 +388,112 @@ func (g *DockerPerUserGateway) dockerReq(ctx context.Context, method, path strin
 		req.Header.Set("Content-Type", "application/json")
 	}
 	return g.httpc.Do(req)
+}
+
+// dockerStatsJSON is the subset of Docker's /containers/{id}/stats payload we
+// need. Field names match the Engine API exactly.
+type dockerStatsJSON struct {
+	CPUStats struct {
+		CPUUsage struct {
+			TotalUsage  int64   `json:"total_usage"`
+			PercpuUsage []int64 `json:"percpu_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage int64 `json:"system_cpu_usage"`
+		OnlineCPUs     int   `json:"online_cpus"`
+	} `json:"cpu_stats"`
+	PreCPUStats struct {
+		CPUUsage struct {
+			TotalUsage int64 `json:"total_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage int64 `json:"system_cpu_usage"`
+	} `json:"precpu_stats"`
+	MemoryStats struct {
+		Usage int64 `json:"usage"`
+		Limit int64 `json:"limit"`
+		Stats struct {
+			Cache        int64 `json:"cache"`
+			InactiveFile int64 `json:"inactive_file"`
+		} `json:"stats"`
+	} `json:"memory_stats"`
+}
+
+// Usage reports live CPU%/memory for the user's kernel container via Docker's
+// stats endpoint. With stream=false the daemon returns a single snapshot that
+// already includes precpu_stats, so one call yields a valid CPU delta. Results
+// are cached for usageTTL to bound load (the stats call is ~1s).
+func (g *DockerPerUserGateway) Usage(ctx context.Context, userID string) (ResourceUsage, error) {
+	name := dockerContainerName(userID)
+
+	g.usageMu.Lock()
+	if c, ok := g.usageCache[name]; ok && time.Since(c.at) < usageTTL {
+		g.usageMu.Unlock()
+		return c.usage, nil
+	}
+	g.usageMu.Unlock()
+
+	resp, err := g.dockerReq(ctx, "GET", "/containers/"+name+"/stats?stream=false", nil)
+	if err != nil {
+		return ResourceUsage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 404 {
+		// No container (not connected / reaped) — nothing to measure.
+		return ResourceUsage{}, ErrUsageUnsupported
+	}
+	if resp.StatusCode != 200 {
+		return ResourceUsage{}, fmt.Errorf("docker stats %s: status %d", name, resp.StatusCode)
+	}
+
+	var s dockerStatsJSON
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return ResourceUsage{}, fmt.Errorf("decode docker stats: %w", err)
+	}
+
+	// Cores actually consumed in the sample window: (container delta / system
+	// delta) * online CPUs — the numerator `docker stats` builds before
+	// turning it into a percentage.
+	var usedCores float64
+	cpuDelta := float64(s.CPUStats.CPUUsage.TotalUsage - s.PreCPUStats.CPUUsage.TotalUsage)
+	sysDelta := float64(s.CPUStats.SystemCPUUsage - s.PreCPUStats.SystemCPUUsage)
+	cpus := s.CPUStats.OnlineCPUs
+	if cpus == 0 {
+		cpus = len(s.CPUStats.CPUUsage.PercpuUsage)
+	}
+	if cpuDelta > 0 && sysDelta > 0 && cpus > 0 {
+		usedCores = (cpuDelta / sysDelta) * float64(cpus)
+	}
+	// Express as a percentage of the container's OWN quota so 100% = "using
+	// the whole limit" (consistent with how RAM is shown vs its limit). With
+	// a 2-core limit this caps near 100% instead of the confusing 200% a raw
+	// docker-stats percentage would show. Falls back to %-of-host when the
+	// container has no CPU limit.
+	cpuPct := 0.0
+	limitCores := float64(g.cfg.nanoCPUs) / 1e9
+	if limitCores <= 0 {
+		limitCores = float64(cpus)
+	}
+	if limitCores > 0 {
+		cpuPct = usedCores / limitCores * 100.0
+	}
+
+	// Memory: subtract page cache so the figure reflects the working set (what
+	// `docker stats` shows), not cache that the kernel will evict under pressure.
+	memUsed := s.MemoryStats.Usage - s.MemoryStats.Stats.InactiveFile
+	if memUsed < 0 {
+		memUsed = s.MemoryStats.Usage
+	}
+
+	usage := ResourceUsage{
+		CPUPercent:    cpuPct,
+		MemUsedBytes:  memUsed,
+		MemLimitBytes: s.MemoryStats.Limit,
+	}
+
+	g.usageMu.Lock()
+	g.usageCache[name] = cachedUsage{usage: usage, at: time.Now()}
+	g.usageMu.Unlock()
+
+	return usage, nil
 }
 
 func (g *DockerPerUserGateway) containerExists(ctx context.Context, name string) bool {

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -156,6 +156,14 @@ func NewK8sPerUserGateway(cfg K8sPerUserConfig) (*K8sPerUserGateway, error) {
 func (g *K8sPerUserGateway) IdleTimeout() time.Duration { return g.cfg.IdleTimeout }
 func (g *K8sPerUserGateway) Mode() string               { return "k8s_per_user" }
 
+// Usage is not yet implemented for k8s. Live pod metrics require metrics-server
+// (metrics.k8s.io), which isn't guaranteed present in a cluster, so this is
+// deferred to a follow-up. Returning ErrUsageUnsupported makes the FE hide the
+// widget rather than error. See the docker_per_user implementation for the model.
+func (g *K8sPerUserGateway) Usage(_ context.Context, _ string) (ResourceUsage, error) {
+	return ResourceUsage{}, ErrUsageUnsupported
+}
+
 // podNameForUser returns a DNS-safe, deterministic pod name for a user ID.
 func podNameForUser(userID string) string {
 	h := sha1.Sum([]byte(userID))

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -156,12 +156,73 @@ func NewK8sPerUserGateway(cfg K8sPerUserConfig) (*K8sPerUserGateway, error) {
 func (g *K8sPerUserGateway) IdleTimeout() time.Duration { return g.cfg.IdleTimeout }
 func (g *K8sPerUserGateway) Mode() string               { return "k8s_per_user" }
 
-// Usage is not yet implemented for k8s. Live pod metrics require metrics-server
-// (metrics.k8s.io), which isn't guaranteed present in a cluster, so this is
-// deferred to a follow-up. Returning ErrUsageUnsupported makes the FE hide the
-// widget rather than error. See the docker_per_user implementation for the model.
-func (g *K8sPerUserGateway) Usage(_ context.Context, _ string) (ResourceUsage, error) {
-	return ResourceUsage{}, ErrUsageUnsupported
+// Usage reports the user's pod CPU/memory. Limits come from the pod spec
+// (always available); live usage comes from metrics-server via the
+// metrics.k8s.io API. If metrics-server isn't installed/ready the metrics
+// call fails and we return ErrUsageUnsupported so the FE hides the widget
+// rather than show a limit with no usage.
+func (g *K8sPerUserGateway) Usage(ctx context.Context, userID string) (ResourceUsage, error) {
+	podName := podNameForUser(userID)
+
+	// Limits from the pod spec.
+	pod, err := g.client.CoreV1().Pods(g.cfg.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return ResourceUsage{}, ErrUsageUnsupported // no pod → nothing to measure
+	}
+	var cpuLimitCores float64
+	var memLimitBytes int64
+	if len(pod.Spec.Containers) > 0 {
+		lim := pod.Spec.Containers[0].Resources.Limits
+		if q, ok := lim[corev1.ResourceCPU]; ok {
+			cpuLimitCores = q.AsApproximateFloat64()
+		}
+		if q, ok := lim[corev1.ResourceMemory]; ok {
+			memLimitBytes = int64(q.AsApproximateFloat64())
+		}
+	}
+
+	// Live usage from metrics-server. AbsPath bypasses the CoreV1 /api/v1 base
+	// so we can hit the aggregated metrics.k8s.io API with the existing client.
+	raw, err := g.client.CoreV1().RESTClient().Get().
+		AbsPath("/apis/metrics.k8s.io/v1beta1/namespaces/" + g.cfg.Namespace + "/pods/" + podName).
+		DoRaw(ctx)
+	if err != nil {
+		// metrics-server absent or not ready yet.
+		return ResourceUsage{}, ErrUsageUnsupported
+	}
+	var pm struct {
+		Containers []struct {
+			Usage struct {
+				CPU    string `json:"cpu"`
+				Memory string `json:"memory"`
+			} `json:"usage"`
+		} `json:"containers"`
+	}
+	if err := json.Unmarshal(raw, &pm); err != nil {
+		return ResourceUsage{}, fmt.Errorf("decode pod metrics: %w", err)
+	}
+	var usedCores float64
+	var usedBytes int64
+	for _, cm := range pm.Containers {
+		if q, err := resource.ParseQuantity(cm.Usage.CPU); err == nil {
+			usedCores += q.AsApproximateFloat64()
+		}
+		if q, err := resource.ParseQuantity(cm.Usage.Memory); err == nil {
+			usedBytes += int64(q.AsApproximateFloat64())
+		}
+	}
+
+	cpuPct := 0.0
+	if cpuLimitCores > 0 {
+		cpuPct = usedCores / cpuLimitCores * 100.0
+	}
+	return ResourceUsage{
+		CPUPercent:    cpuPct,
+		CPUUsedCores:  usedCores,
+		CPULimitCores: cpuLimitCores,
+		MemUsedBytes:  usedBytes,
+		MemLimitBytes: memLimitBytes,
+	}, nil
 }
 
 // podNameForUser returns a DNS-safe, deterministic pod name for a user ID.

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -63,7 +63,9 @@ type KernelGateway interface {
 // is capped at); 0 means "no limit set" so the UI should fall back to the
 // host total or hide the denominator.
 type ResourceUsage struct {
-	CPUPercent    float64 `json:"cpu_percent"`
+	CPUPercent    float64 `json:"cpu_percent"`     // 0–100, relative to the container's CPU quota
+	CPUUsedCores  float64 `json:"cpu_used_cores"`  // cores currently consumed (e.g. 0.24)
+	CPULimitCores float64 `json:"cpu_limit_cores"` // quota in cores (e.g. 2); 0 = unlimited
 	MemUsedBytes  int64   `json:"mem_used_bytes"`
 	MemLimitBytes int64   `json:"mem_limit_bytes"`
 }

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -49,7 +49,29 @@ type KernelGateway interface {
 	// learn when phase reaches "ready". SharedGateway is a pure no-op since
 	// there's nothing to spawn.
 	EnsureSpawning(userID string) error
+
+	// Usage returns live CPU/memory usage of the user's kernel container/pod.
+	// Returns ErrUsageUnsupported when the mode has no per-user container to
+	// measure (shared) or the metric source is unavailable (k8s without
+	// metrics-server) — callers should treat that as "hide the widget", not
+	// a hard error.
+	Usage(ctx context.Context, userID string) (ResourceUsage, error)
 }
+
+// ResourceUsage is a point-in-time snapshot of a kernel container/pod's
+// resource consumption. MemLimitBytes is the cgroup/pod limit (what the user
+// is capped at); 0 means "no limit set" so the UI should fall back to the
+// host total or hide the denominator.
+type ResourceUsage struct {
+	CPUPercent    float64 `json:"cpu_percent"`
+	MemUsedBytes  int64   `json:"mem_used_bytes"`
+	MemLimitBytes int64   `json:"mem_limit_bytes"`
+}
+
+// ErrUsageUnsupported signals that resource usage can't be measured for this
+// gateway mode / user. Handlers map it to an "unavailable" response rather
+// than a 500.
+var ErrUsageUnsupported = fmt.Errorf("resource usage not supported")
 
 // DefaultKernelImage is the canonical public kernel image. Used as the fallback
 // in both Docker and K8s per-user gateways when KERNEL_POD_IMAGE isn't set in
@@ -81,6 +103,10 @@ func (s *SharedGateway) Status(_ string) (PodStatus, error) {
 	return PodStatus{Phase: PhaseReady, Message: "Kernel ready", URL: s.url}, nil
 }
 func (s *SharedGateway) EnsureSpawning(_ string) error { return nil }
+func (s *SharedGateway) Usage(_ context.Context, _ string) (ResourceUsage, error) {
+	// One shared container for everyone — no per-user figure to report.
+	return ResourceUsage{}, ErrUsageUnsupported
+}
 
 // KernelGatewaySettings is the fully-resolved config needed to build a gateway.
 // Populated from *config.Config in main.go so this package doesn't depend on

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -26,6 +26,11 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "create", "delete"]
+  # Read per-user pod CPU/memory for the Resource Usage widget. Requires
+  # metrics-server installed in the cluster; without it the widget hides.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -23,6 +23,7 @@ import {
     Search,
     X,
     Power,
+    PowerOff,
     Pencil,
     Package,
     Cloud,
@@ -1728,7 +1729,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 className={`${toolbarBtnBase} w-8 p-0 border-red-500 text-red-600 hover:bg-red-50 hover:text-red-700`}
                                 title="Disconnect from kernel"
                             >
-                                <X className="size-3" />
+                                <PowerOff className="size-3" />
                             </Button>
                         ) : connectionStatus === 'connecting' ? (
                             <Button

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -76,6 +76,7 @@ import { SidebarFiles } from './SidebarFiles';
 import { ConnectionStatusBadge } from './parts/ConnectionStatusBadge';
 import { LanguageIcon } from './parts/LanguageIcon';
 import { CellEditor } from './parts/CellEditor';
+import { ResourceUsageBadge } from './parts/ResourceUsageBadge';
 import { registerAllStaticProviders } from './monaco/registerStatic';
 import { SidebarIconRail, SidebarTab } from './parts/SidebarIconRail';
 
@@ -1626,7 +1627,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                     </div>
 
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 shrink-0">
+                        {/* Live kernel CPU/RAM — hidden unless usage is available */}
+                        <ResourceUsageBadge enabled={connectionStatus === 'connected'} compact={compactToolbar} />
+
                         {/* Libraries button */}
                         {connectionStatus === 'connected' && (
                             <Button
@@ -1696,11 +1700,11 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             );
                         })()}
 
-                        {/* Clear All Outputs button */}
+                        {/* Clear All Outputs — icon-only to keep the toolbar compact */}
                         <Button
                             variant="outline"
                             size="sm"
-                            className={`${toolbarBtnBase} ${toolbarBtnCompact}`}
+                            className={`${toolbarBtnBase} w-8 p-0`}
                             onClick={async () => {
                                 for (const cell of cells) {
                                     if (cell.type === 'code') {
@@ -1711,7 +1715,6 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             title="Clear All Outputs"
                         >
                             <Eraser className="size-3" />
-                            {!compactToolbar && <span>Clear Output</span>}
                         </Button>
 
                         {/* Connect/Disconnect button — fixed minWidth so all
@@ -1722,12 +1725,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 variant="outline"
                                 size="sm"
                                 onClick={handleDisconnect}
-                                style={{ minWidth: compactToolbar ? undefined : 105 }}
-                                className={`${toolbarBtnBase} ${toolbarBtnCompact} border-red-500 text-red-600 hover:bg-red-50 hover:text-red-700`}
+                                className={`${toolbarBtnBase} w-8 p-0 border-red-500 text-red-600 hover:bg-red-50 hover:text-red-700`}
                                 title="Disconnect from kernel"
                             >
                                 <X className="size-3" />
-                                {!compactToolbar && <span>Disconnect</span>}
                             </Button>
                         ) : connectionStatus === 'connecting' ? (
                             <Button
@@ -1735,35 +1736,29 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 size="sm"
                                 disabled
                                 title="Connecting..."
-                                style={{ minWidth: compactToolbar ? undefined : 105 }}
-                                className={`${toolbarBtnBase} ${toolbarBtnCompact}`}
+                                className={`${toolbarBtnBase} w-8 p-0`}
                             >
                                 <Loader2 className="size-3 animate-spin" />
-                                {!compactToolbar && <span>Connecting...</span>}
                             </Button>
                         ) : podPhase === 'terminating' ? (
                             <Button
                                 variant="outline"
                                 size="sm"
                                 disabled
-                                style={{ minWidth: compactToolbar ? undefined : 105 }}
-                                className={`${toolbarBtnBase} ${toolbarBtnCompact} border-amber-500 text-amber-600`}
+                                className={`${toolbarBtnBase} w-8 p-0 border-amber-500 text-amber-600`}
                                 title={podMessage || 'Waiting for previous pod to shut down…'}
                             >
                                 <Loader2 className="size-3 animate-spin" />
-                                {!compactToolbar && <span>Shutting down…</span>}
                             </Button>
                         ) : (
                             <Button
                                 variant="outline"
                                 size="sm"
                                 onClick={handleConnect}
-                                style={{ minWidth: compactToolbar ? undefined : 105 }}
-                                className={`${toolbarBtnBase} ${toolbarBtnCompact} border-blue-500 text-blue-600 hover:bg-blue-50 hover:text-blue-700`}
+                                className={`${toolbarBtnBase} w-8 p-0 border-blue-500 text-blue-600 hover:bg-blue-50 hover:text-blue-700`}
                                 title="Connect to kernel"
                             >
                                 <Power className="size-3" />
-                                {!compactToolbar && <span>Connect</span>}
                             </Button>
                         )}
 

--- a/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
@@ -64,7 +64,10 @@ export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean 
     const limitGB = (usage.mem_limit_bytes ?? 0) / 1024 ** 3;
     const memPct = limitGB > 0 ? Math.round((usedGB / limitGB) * 100) : 0;
 
-    const cpuDetail = limitCores > 0 ? `${trim(usedCores)}/${trim(limitCores)} vCPU` : `${trim(usedCores)} vCPU`;
+    // Always one decimal on the "used" figure so its width is constant — "0.0/2"
+    // and "1.4/2" take the same space, so the widget doesn't jump as values
+    // change. The limit is fixed, so trim its trailing ".0".
+    const cpuDetail = limitCores > 0 ? `${usedCores.toFixed(1)}/${trim(limitCores)} vCPU` : `${usedCores.toFixed(1)} vCPU`;
     const memDetail = limitGB > 0 ? `${usedGB.toFixed(1)}/${trim(limitGB)} GB` : `${usedGB.toFixed(1)} GB`;
     const title = `Kernel CPU ${cpuPct}% (${cpuDetail}) · RAM ${memPct}% (${memDetail})`;
 

--- a/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
@@ -68,18 +68,21 @@ export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean 
     const memDetail = limitGB > 0 ? `${usedGB.toFixed(1)}/${trim(limitGB)} GB` : `${usedGB.toFixed(1)} GB`;
     const title = `Kernel CPU ${cpuPct}% (${cpuDetail}) · RAM ${memPct}% (${memDetail})`;
 
-    return (
-        <div
-            className="grid grid-cols-[auto_auto_auto] gap-x-1.5 gap-y-0 items-center text-[10px] leading-[1.2] tabular-nums"
-            title={title}
-        >
-            <span className="text-muted-foreground">CPU</span>
-            <span className={`text-right ${sevColor(cpuPct)}`}>{cpuPct}%</span>
-            {compact ? <span /> : <span className="text-muted-foreground">{cpuDetail}</span>}
+    // Two flex rows with fixed-width cells so the columns line up. Avoid
+    // Tailwind arbitrary grid-cols-[...] which didn't render here (the spans
+    // stacked vertically instead of forming columns).
+    const Row: React.FC<{ label: string; pct: number; detail: string }> = ({ label, pct, detail }) => (
+        <div className="flex items-center gap-1.5 whitespace-nowrap">
+            <span className="w-7 text-muted-foreground">{label}</span>
+            <span className={`w-8 text-right ${sevColor(pct)}`}>{pct}%</span>
+            {!compact && <span className="text-muted-foreground">{detail}</span>}
+        </div>
+    );
 
-            <span className="text-muted-foreground">RAM</span>
-            <span className={`text-right ${sevColor(memPct)}`}>{memPct}%</span>
-            {compact ? <span /> : <span className="text-muted-foreground">{memDetail}</span>}
+    return (
+        <div className="flex flex-col leading-[1.25] text-[10px] tabular-nums shrink-0" title={title}>
+            <Row label="CPU" pct={cpuPct} detail={cpuDetail} />
+            <Row label="RAM" pct={memPct} detail={memDetail} />
         </div>
     );
 };

--- a/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
@@ -75,9 +75,11 @@ export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean 
     // Tailwind arbitrary grid-cols-[...] which didn't render here (the spans
     // stacked vertically instead of forming columns).
     const Row: React.FC<{ label: string; pct: number; detail: string }> = ({ label, pct, detail }) => (
-        <div className="flex items-center gap-1.5 whitespace-nowrap">
-            <span className="w-7 text-muted-foreground">{label}</span>
-            <span className={`w-8 text-right ${sevColor(pct)}`}>{pct}%</span>
+        <div className="flex items-center gap-1 whitespace-nowrap">
+            <span className="text-muted-foreground">{label}</span>
+            {/* Just wide enough for "100%"; right-aligned so the detail column
+                still lines up between the two rows without a big gap. */}
+            <span className={`w-[1.9rem] text-right ${sevColor(pct)}`}>{pct}%</span>
             {!compact && <span className="text-muted-foreground">{detail}</span>}
         </div>
     );

--- a/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { Cpu, MemoryStick } from 'lucide-react';
+
+interface Usage {
+    available: boolean;
+    cpu_percent?: number;
+    mem_used_bytes?: number;
+    mem_limit_bytes?: number;
+}
+
+// Live CPU/RAM of the current user's kernel container. Polls /kernel/usage
+// only while `enabled` (kernel connected). Renders nothing when usage isn't
+// available — shared mode, no container yet, or k8s without metrics-server all
+// return {available:false}, so the widget simply disappears instead of showing
+// zeros or an error.
+export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean }> = ({ enabled, compact = false }) => {
+    const [usage, setUsage] = useState<Usage | null>(null);
+    // Avoid a state update (and re-render) after unmount / disable.
+    const aliveRef = useRef(true);
+
+    useEffect(() => {
+        aliveRef.current = true;
+        if (!enabled) {
+            setUsage(null);
+            return () => { aliveRef.current = false; };
+        }
+        let timer: ReturnType<typeof setTimeout>;
+        const poll = async () => {
+            try {
+                const res = await axios.get<Usage>('/api/v1/kernel/usage', { timeout: 3000 });
+                if (aliveRef.current) setUsage(res.data);
+            } catch {
+                // Transient failure — keep the last good value, try again next tick.
+            }
+            if (aliveRef.current) timer = setTimeout(poll, 4000);
+        };
+        poll();
+        return () => { aliveRef.current = false; clearTimeout(timer); };
+    }, [enabled]);
+
+    if (!enabled || !usage?.available) return null;
+
+    const cpu = Math.max(0, Math.round(usage.cpu_percent ?? 0));
+    const usedGB = (usage.mem_used_bytes ?? 0) / 1024 ** 3;
+    const limitGB = (usage.mem_limit_bytes ?? 0) / 1024 ** 3;
+    const memPct = limitGB > 0 ? (usedGB / limitGB) * 100 : 0;
+
+    // Color by the hotter of the two signals.
+    const severity = Math.max(cpu, memPct);
+    const color =
+        severity >= 80 ? 'text-rose-500'
+            : severity >= 60 ? 'text-amber-500'
+                : 'text-muted-foreground';
+
+    const ramText = limitGB > 0
+        ? `${usedGB.toFixed(1)}/${limitGB.toFixed(0)} GB`
+        : `${usedGB.toFixed(1)} GB`;
+    const title = `Kernel CPU ${cpu}% · RAM ${ramText}`;
+
+    return (
+        <div className={`flex items-center gap-2 text-xs shrink-0 whitespace-nowrap ${color}`} title={title}>
+            <span className="flex items-center gap-1 tabular-nums">
+                <Cpu className="size-3" />
+                {cpu}%
+            </span>
+            {!compact && (
+                <span className="flex items-center gap-1 tabular-nums">
+                    <MemoryStick className="size-3" />
+                    {ramText}
+                </span>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ResourceUsageBadge.tsx
@@ -1,22 +1,37 @@
 import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
-import { Cpu, MemoryStick } from 'lucide-react';
 
 interface Usage {
     available: boolean;
     cpu_percent?: number;
+    cpu_used_cores?: number;
+    cpu_limit_cores?: number;
     mem_used_bytes?: number;
     mem_limit_bytes?: number;
 }
 
-// Live CPU/RAM of the current user's kernel container. Polls /kernel/usage
-// only while `enabled` (kernel connected). Renders nothing when usage isn't
-// available — shared mode, no container yet, or k8s without metrics-server all
-// return {available:false}, so the widget simply disappears instead of showing
-// zeros or an error.
+// Color a metric by how close it is to its limit.
+function sevColor(pct: number): string {
+    if (pct >= 80) return 'text-rose-500';
+    if (pct >= 60) return 'text-amber-500';
+    return 'text-foreground';
+}
+
+// Drop a trailing ".0" so whole numbers read cleanly ("2" not "2.0").
+function trim(n: number): string {
+    return n.toFixed(1).replace(/\.0$/, '');
+}
+
+// Live CPU/RAM of the current user's kernel container, as a compact two-row
+// readout that lines up in columns:
+//
+//   CPU  12%   0.2/2 vCPU
+//   RAM  34%   0.8/4 GB
+//
+// Polls /kernel/usage every 4s only while `enabled`. Renders nothing when
+// usage isn't available (shared mode, no container, k8s without metrics).
 export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean }> = ({ enabled, compact = false }) => {
     const [usage, setUsage] = useState<Usage | null>(null);
-    // Avoid a state update (and re-render) after unmount / disable.
     const aliveRef = useRef(true);
 
     useEffect(() => {
@@ -31,7 +46,7 @@ export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean 
                 const res = await axios.get<Usage>('/api/v1/kernel/usage', { timeout: 3000 });
                 if (aliveRef.current) setUsage(res.data);
             } catch {
-                // Transient failure — keep the last good value, try again next tick.
+                // keep last good value
             }
             if (aliveRef.current) timer = setTimeout(poll, 4000);
         };
@@ -41,35 +56,30 @@ export const ResourceUsageBadge: React.FC<{ enabled: boolean; compact?: boolean 
 
     if (!enabled || !usage?.available) return null;
 
-    const cpu = Math.max(0, Math.round(usage.cpu_percent ?? 0));
+    const cpuPct = Math.max(0, Math.round(usage.cpu_percent ?? 0));
+    const usedCores = usage.cpu_used_cores ?? 0;
+    const limitCores = usage.cpu_limit_cores ?? 0;
+
     const usedGB = (usage.mem_used_bytes ?? 0) / 1024 ** 3;
     const limitGB = (usage.mem_limit_bytes ?? 0) / 1024 ** 3;
-    const memPct = limitGB > 0 ? (usedGB / limitGB) * 100 : 0;
+    const memPct = limitGB > 0 ? Math.round((usedGB / limitGB) * 100) : 0;
 
-    // Color by the hotter of the two signals.
-    const severity = Math.max(cpu, memPct);
-    const color =
-        severity >= 80 ? 'text-rose-500'
-            : severity >= 60 ? 'text-amber-500'
-                : 'text-muted-foreground';
-
-    const ramText = limitGB > 0
-        ? `${usedGB.toFixed(1)}/${limitGB.toFixed(0)} GB`
-        : `${usedGB.toFixed(1)} GB`;
-    const title = `Kernel CPU ${cpu}% · RAM ${ramText}`;
+    const cpuDetail = limitCores > 0 ? `${trim(usedCores)}/${trim(limitCores)} vCPU` : `${trim(usedCores)} vCPU`;
+    const memDetail = limitGB > 0 ? `${usedGB.toFixed(1)}/${trim(limitGB)} GB` : `${usedGB.toFixed(1)} GB`;
+    const title = `Kernel CPU ${cpuPct}% (${cpuDetail}) · RAM ${memPct}% (${memDetail})`;
 
     return (
-        <div className={`flex items-center gap-2 text-xs shrink-0 whitespace-nowrap ${color}`} title={title}>
-            <span className="flex items-center gap-1 tabular-nums">
-                <Cpu className="size-3" />
-                {cpu}%
-            </span>
-            {!compact && (
-                <span className="flex items-center gap-1 tabular-nums">
-                    <MemoryStick className="size-3" />
-                    {ramText}
-                </span>
-            )}
+        <div
+            className="grid grid-cols-[auto_auto_auto] gap-x-1.5 gap-y-0 items-center text-[10px] leading-[1.2] tabular-nums"
+            title={title}
+        >
+            <span className="text-muted-foreground">CPU</span>
+            <span className={`text-right ${sevColor(cpuPct)}`}>{cpuPct}%</span>
+            {compact ? <span /> : <span className="text-muted-foreground">{cpuDetail}</span>}
+
+            <span className="text-muted-foreground">RAM</span>
+            <span className={`text-right ${sevColor(memPct)}`}>{memPct}%</span>
+            {compact ? <span /> : <span className="text-muted-foreground">{memDetail}</span>}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
Adds a compact toolbar widget showing the current user's kernel container/pod resource usage, for self-hosted per-user-isolation deployments:

```
CPU  12%   0.2/2 vCPU
RAM  34%   0.8/4 GB
```

## Backend
- `KernelGateway.Usage(ctx, userID) (ResourceUsage, error)` + `ErrUsageUnsupported`.
- **docker_per_user**: Docker `/containers/{name}/stats?stream=false` (single snapshot → valid CPU delta), cached 2s.
- **k8s_per_user**: limits from pod spec + live usage from metrics-server (`metrics.k8s.io`) via the existing clientset RESTClient (no new dep).
- CPU normalized to the container's own quota (100% = full limit), matching how RAM reads against its limit.
- shared mode / no container / no metrics-server → `ErrUsageUnsupported` → widget hides (never a 500).
- `GET /api/v1/kernel/usage` returns {available, cpu_percent, cpu_used_cores, cpu_limit_cores, mem_used_bytes, mem_limit_bytes}.
- **chart**: backend RBAC gains `metrics.k8s.io/pods` get/list (required for the k8s path).

## Frontend
- `ResourceUsageBadge`: polls `/kernel/usage` every 4s only while connected, hides when unavailable; two-row column-aligned layout, fixed-decimal so it doesn't jump as values change; compact mode drops the detail column.
- Toolbar: Clear Output + all connect/disconnect states shrunk to icon-only to make room; Disconnect uses PowerOff (mirrors Connect's Power).

## Verified
- **docker_per_user** (docker-compose): `/kernel/usage` returns real CPU/RAM; CPU normalized (~53% under load, not 200%).
- **k8s_per_user** (OrbStack k8s + metrics-server): `available:true` with live numbers from metrics.k8s.io after adding the RBAC rule.
- `go build`/`go vet` clean; frontend tsc clean.