### PR TITLE
feat(kernel): per-session resource presets (CPU/RAM picker) — v0.2.0

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -223,6 +223,7 @@ func main() {
 		{
 			kernelMeta.GET("/spawn-status", localKernelHandler.SpawnStatus)
 			kernelMeta.GET("/usage", localKernelHandler.Usage)
+			kernelMeta.GET("/resource-presets", localKernelHandler.ResourcePresets)
 		}
 	}
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
 	"strings"
@@ -64,8 +65,26 @@ type Config struct {
 	KernelPodCPULimit      string
 	KernelPodMemoryLimit   string
 
+	// Per-notebook resource presets (k8s_per_user only). When the preset list is
+	// empty the feature is disabled and every pod uses the KernelPod*Limit values
+	// above. Each preset's cpu/memory is applied as BOTH request and limit
+	// (Guaranteed QoS) so a user gets exactly what they pick.
+	KernelResourcePresets       []ResourcePreset
+	KernelResourceDefaultPreset string // id of the preset pre-selected in the UI
+	KernelResourceAllowCustom   bool   // show the "Custom" row in the dialog
+	KernelResourceCustomMaxCPU  string // hard ceiling for custom cpu, e.g. "8"
+	KernelResourceCustomMaxMem  string // hard ceiling for custom memory, e.g. "16Gi"
+
 	// CORS
 	CORSOrigins []string
+}
+
+// ResourcePreset is one selectable kernel-pod size offered to the user.
+type ResourcePreset struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
 }
 
 func Load() *Config {
@@ -113,6 +132,12 @@ func Load() *Config {
 		KernelPodCPULimit:      getEnv("KERNEL_POD_CPU_LIMIT", "2000m"),
 		KernelPodMemoryLimit:   getEnv("KERNEL_POD_MEMORY_LIMIT", "4Gi"),
 
+		KernelResourcePresets:       parseResourcePresets(getEnv("KERNEL_RESOURCE_PRESETS", "")),
+		KernelResourceDefaultPreset: getEnv("KERNEL_RESOURCE_DEFAULT_PRESET", ""),
+		KernelResourceAllowCustom:   getEnvBool("KERNEL_RESOURCE_ALLOW_CUSTOM", false),
+		KernelResourceCustomMaxCPU:  getEnv("KERNEL_RESOURCE_CUSTOM_MAX_CPU", ""),
+		KernelResourceCustomMaxMem:  getEnv("KERNEL_RESOURCE_CUSTOM_MAX_MEMORY", ""),
+
 		CORSOrigins: strings.Split(getEnv("CORS_ORIGINS", "http://localhost:3000"), ","),
 	}
 }
@@ -131,4 +156,38 @@ func getEnvInt(key string, fallback int) int {
 		}
 	}
 	return fallback
+}
+
+func getEnvBool(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		if b, err := strconv.ParseBool(value); err == nil {
+			return b
+		}
+	}
+	return fallback
+}
+
+// parseResourcePresets reads the KERNEL_RESOURCE_PRESETS JSON array. Malformed
+// JSON or entries missing cpu/memory are dropped (logged at the call site is
+// overkill for config) so a typo disables presets rather than crashing boot.
+func parseResourcePresets(raw string) []ResourcePreset {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var presets []ResourcePreset
+	if err := json.Unmarshal([]byte(raw), &presets); err != nil {
+		return nil
+	}
+	out := presets[:0]
+	for _, p := range presets {
+		if p.ID == "" || p.CPU == "" || p.Memory == "" {
+			continue
+		}
+		if p.Label == "" {
+			p.Label = p.ID
+		}
+		out = append(out, p)
+	}
+	return out
 }

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -83,6 +83,13 @@ func MigrateAndSeed(cfg *config.Config) error {
 			last_used_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_user_kernel_pods_idle ON user_kernel_pods(status, last_used_at)`,
+		// Per-pod resources chosen at connect time (issue #41, k8s_per_user
+		// presets). Empty string on legacy rows → gateway falls back to cluster
+		// defaults, so no backfill is needed.
+		`ALTER TABLE user_kernel_pods ADD COLUMN IF NOT EXISTS cpu_request TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE user_kernel_pods ADD COLUMN IF NOT EXISTS mem_request TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE user_kernel_pods ADD COLUMN IF NOT EXISTS cpu_limit TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE user_kernel_pods ADD COLUMN IF NOT EXISTS mem_limit TEXT NOT NULL DEFAULT ''`,
 
 		// Notebook→kernel cache (UNLOGGED, regenerable)
 		`CREATE UNLOGGED TABLE IF NOT EXISTS notebook_kernels (

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/sparklabx/sparklabx/backend/internal/config"
 	"github.com/sparklabx/sparklabx/backend/internal/database"
@@ -27,6 +28,15 @@ import (
 type LocalKernelHandler struct {
 	gateway  services.KernelGateway
 	upgrader websocket.Upgrader
+
+	// Per-notebook resource presets (k8s_per_user only, issue #41). An empty
+	// preset list means the feature is off: Connect ignores any resources field
+	// and the presets endpoint reports enabled=false.
+	resourcePresets       []config.ResourcePreset
+	resourceDefaultPreset string
+	resourceAllowCustom   bool
+	resourceCustomMaxCPU  string
+	resourceCustomMaxMem  string
 }
 
 func NewLocalKernelHandler(cfg *config.Config, gateway services.KernelGateway) *LocalKernelHandler {
@@ -35,7 +45,12 @@ func NewLocalKernelHandler(cfg *config.Config, gateway services.KernelGateway) *
 		allowedOrigins[o] = true
 	}
 	return &LocalKernelHandler{
-		gateway: gateway,
+		gateway:               gateway,
+		resourcePresets:       cfg.KernelResourcePresets,
+		resourceDefaultPreset: cfg.KernelResourceDefaultPreset,
+		resourceAllowCustom:   cfg.KernelResourceAllowCustom,
+		resourceCustomMaxCPU:  cfg.KernelResourceCustomMaxCPU,
+		resourceCustomMaxMem:  cfg.KernelResourceCustomMaxMem,
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				origin := r.Header.Get("Origin")
@@ -354,6 +369,94 @@ func parseKernelKey(key string) (notebookID, userID string) {
 // 'ready'), so docker-compose flow is unchanged.
 //
 // POST /api/v1/notebooks/:id/kernel/connect
+// connectResources is the optional resources block in a /kernel/connect body.
+// Either preset (an id from the configured list) OR custom (explicit CPU/memory)
+// — preset wins if both are sent.
+type connectResources struct {
+	Preset string `json:"preset"`
+	Custom *struct {
+		CPU    string `json:"cpu"`
+		Memory string `json:"memory"`
+	} `json:"custom"`
+}
+
+// resolveResources validates a connect request's resources field against the
+// configured presets/caps and returns the pod size to spawn with.
+//   - (nil, nil): feature off, or no resources requested → gateway uses defaults.
+//   - (spec, nil): a valid preset or custom size.
+//   - (nil, err): client sent something invalid → handler returns 400.
+func (h *LocalKernelHandler) resolveResources(r *connectResources) (*services.ResourceSpec, error) {
+	if len(h.resourcePresets) == 0 || r == nil {
+		return nil, nil
+	}
+
+	if r.Preset != "" {
+		for _, p := range h.resourcePresets {
+			if p.ID == r.Preset {
+				return &services.ResourceSpec{CPU: p.CPU, Memory: p.Memory}, nil
+			}
+		}
+		return nil, fmt.Errorf("unknown resource preset %q", r.Preset)
+	}
+
+	if r.Custom != nil {
+		if !h.resourceAllowCustom {
+			return nil, fmt.Errorf("custom resources are not allowed")
+		}
+		cpu, mem := strings.TrimSpace(r.Custom.CPU), strings.TrimSpace(r.Custom.Memory)
+		if cpu == "" || mem == "" {
+			return nil, fmt.Errorf("custom resources require both cpu and memory")
+		}
+		cpuQ, err := resource.ParseQuantity(cpu)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cpu quantity %q", cpu)
+		}
+		memQ, err := resource.ParseQuantity(mem)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory quantity %q", mem)
+		}
+		if cpuQ.Sign() <= 0 || memQ.Sign() <= 0 {
+			return nil, fmt.Errorf("cpu and memory must be positive")
+		}
+		if h.resourceCustomMaxCPU != "" {
+			if maxQ, err := resource.ParseQuantity(h.resourceCustomMaxCPU); err == nil && cpuQ.Cmp(maxQ) > 0 {
+				return nil, fmt.Errorf("cpu %s exceeds the allowed max of %s", cpu, h.resourceCustomMaxCPU)
+			}
+		}
+		if h.resourceCustomMaxMem != "" {
+			if maxQ, err := resource.ParseQuantity(h.resourceCustomMaxMem); err == nil && memQ.Cmp(maxQ) > 0 {
+				return nil, fmt.Errorf("memory %s exceeds the allowed max of %s", mem, h.resourceCustomMaxMem)
+			}
+		}
+		return &services.ResourceSpec{CPU: cpu, Memory: mem}, nil
+	}
+
+	return nil, nil
+}
+
+// ResourcePresets serves the configured kernel-pod sizes to the frontend so the
+// Connect dialog can render a picker. enabled=false (empty preset list) tells
+// the UI to hide the Resources section entirely.
+func (h *LocalKernelHandler) ResourcePresets(c *gin.Context) {
+	presets := make([]gin.H, 0, len(h.resourcePresets))
+	for _, p := range h.resourcePresets {
+		presets = append(presets, gin.H{
+			"id":     p.ID,
+			"label":  p.Label,
+			"cpu":    p.CPU,
+			"memory": p.Memory,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":        len(h.resourcePresets) > 0,
+		"presets":        presets,
+		"default_preset": h.resourceDefaultPreset,
+		"allow_custom":   h.resourceAllowCustom,
+		"max_cpu":        h.resourceCustomMaxCPU,
+		"max_memory":     h.resourceCustomMaxMem,
+	})
+}
+
 func (h *LocalKernelHandler) Connect(c *gin.Context) {
 	startKernelCleanup(h.gateway)
 
@@ -365,11 +468,18 @@ func (h *LocalKernelHandler) Connect(c *gin.Context) {
 	kernelKey := kernelKeyForNotebook(notebookID, userID)
 
 	var req struct {
-		Language   string `json:"language"`
-		KernelName string `json:"kernel_name"`
+		Language   string            `json:"language"`
+		KernelName string            `json:"kernel_name"`
+		Resources  *connectResources `json:"resources"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	resourceSpec, err := h.resolveResources(req.Resources)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -399,7 +509,7 @@ func (h *LocalKernelHandler) Connect(c *gin.Context) {
 
 	// Non-blocking spawn trigger. Returns immediately; in k8s_per_user mode
 	// this kicks off a goroutine that updates DB phase as the pod progresses.
-	if err := h.gateway.EnsureSpawning(userID); err != nil {
+	if err := h.gateway.EnsureSpawning(userID, resourceSpec); err != nil {
 		log.Error().Err(err).Str("user_id", userID).Msg("ensure spawning failed")
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -29,9 +29,9 @@ type LocalKernelHandler struct {
 	gateway  services.KernelGateway
 	upgrader websocket.Upgrader
 
-	// Per-notebook resource presets (k8s_per_user only, issue #41). An empty
-	// preset list means the feature is off: Connect ignores any resources field
-	// and the presets endpoint reports enabled=false.
+	// Per-session resource presets (issue #41, k8s + docker per-user modes).
+	// An empty preset list means the feature is off: Connect ignores any
+	// resources field and the presets endpoint reports enabled=false.
 	resourcePresets       []config.ResourcePreset
 	resourceDefaultPreset string
 	resourceAllowCustom   bool
@@ -434,6 +434,32 @@ func (h *LocalKernelHandler) resolveResources(r *connectResources) (*services.Re
 	return nil, nil
 }
 
+// kernelSizeDiffers reports whether the user's running kernel was created with
+// a different size than spec. Legacy rows with empty resource columns count as
+// "different" — the user explicitly picked a size, so honor it (one extra
+// restart, after which the columns are recorded). Quantities are compared
+// semantically so "4" == "4000m".
+func kernelSizeDiffers(userID string, spec *services.ResourceSpec) bool {
+	var cpu, mem string
+	err := database.GetDB().QueryRow(
+		`SELECT cpu_limit, mem_limit FROM user_kernel_pods WHERE user_id = $1`, userID,
+	).Scan(&cpu, &mem)
+	if err != nil {
+		return false // no row (shared mode / nothing running) — nothing to resize
+	}
+	if cpu == "" || mem == "" {
+		return true
+	}
+	curCPU, err1 := resource.ParseQuantity(cpu)
+	curMem, err2 := resource.ParseQuantity(mem)
+	newCPU, err3 := resource.ParseQuantity(spec.CPU)
+	newMem, err4 := resource.ParseQuantity(spec.Memory)
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return cpu != spec.CPU || mem != spec.Memory
+	}
+	return curCPU.Cmp(newCPU) != 0 || curMem.Cmp(newMem) != 0
+}
+
 // ResourcePresets serves the configured kernel-pod sizes to the frontend so the
 // Connect dialog can render a picker. enabled=false (empty preset list) tells
 // the UI to hide the Resources section entirely.
@@ -505,6 +531,23 @@ func (h *LocalKernelHandler) Connect(c *gin.Context) {
 			"message": st.Message,
 		})
 		return
+	}
+
+	// Resize: a kernel is already running but with a different size than the
+	// user just picked. Container/pod resources are immutable, so honoring the
+	// new size means destroy + respawn (the dialog warns that changing size
+	// restarts the kernel). Only triggers on an explicit size choice AND a real
+	// difference — the FE's connect retry loop re-sends the same preset while
+	// polling, which must NOT loop into restart-on-every-poll.
+	if resourceSpec != nil {
+		if st, _ := h.gateway.Status(userID); st.Phase == services.PhaseReady && kernelSizeDiffers(userID, resourceSpec) {
+			log.Info().Str("user_id", userID).Str("cpu", resourceSpec.CPU).Str("mem", resourceSpec.Memory).
+				Msg("kernel size changed; restarting kernel at new size")
+			if err := h.gateway.Destroy(userID); err != nil {
+				log.Warn().Err(err).Str("user_id", userID).Msg("destroy for resize failed; keeping current kernel")
+			}
+			deleteKernelMap(notebookID, userID)
+		}
 	}
 
 	// Non-blocking spawn trigger. Returns immediately; in k8s_per_user mode

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -418,6 +418,15 @@ func (h *LocalKernelHandler) resolveResources(r *connectResources) (*services.Re
 		if cpuQ.Sign() <= 0 || memQ.Sign() <= 0 {
 			return nil, fmt.Errorf("cpu and memory must be positive")
 		}
+		// Sanity floors. A bare number like "3" parses as 3 BYTES of memory —
+		// almost certainly someone meaning 3 GB — and Docker/k8s would reject
+		// or OOM-kill such a container anyway. Catch it with a clear message.
+		if cpuQ.MilliValue() < 100 {
+			return nil, fmt.Errorf("cpu %s is below the 0.1-core minimum", cpu)
+		}
+		if memQ.Value() < 128<<20 {
+			return nil, fmt.Errorf("memory %s is below the 128Mi minimum (did you mean %sGi?)", mem, mem)
+		}
 		if h.resourceCustomMaxCPU != "" {
 			if maxQ, err := resource.ParseQuantity(h.resourceCustomMaxCPU); err == nil && cpuQ.Cmp(maxQ) > 0 {
 				return nil, fmt.Errorf("cpu %s exceeds the allowed max of %s", cpu, h.resourceCustomMaxCPU)

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -226,7 +226,7 @@ func (g *DockerPerUserGateway) GetGatewayURL(ctx context.Context, userID string)
 	}
 
 	// Spawn fresh
-	if err := g.EnsureSpawning(userID); err != nil {
+	if err := g.EnsureSpawning(userID, nil); err != nil {
 		return "", err
 	}
 
@@ -249,7 +249,11 @@ func (g *DockerPerUserGateway) GetGatewayURL(ctx context.Context, userID string)
 
 // EnsureSpawning creates and starts the user's container if it isn't already
 // running. Idempotent — returns nil if the container exists in any phase.
-func (g *DockerPerUserGateway) EnsureSpawning(userID string) error {
+//
+// spec is accepted for interface parity with the k8s gateway but ignored here:
+// per-notebook resource presets are a k8s_per_user feature (issue #41), and
+// docker_per_user keeps the single configured CPU/memory limit.
+func (g *DockerPerUserGateway) EnsureSpawning(userID string, _ *ResourceSpec) error {
 	if userID == "" {
 		return fmt.Errorf("userID empty")
 	}

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -133,19 +133,19 @@ func dockerContainerName(userID string) string {
 }
 
 // hostConfig builds the Docker HostConfig fragment. Resource limits are
-// only attached when the operator opted in via CPULimit/MemoryLimit — a
-// zero value means "no limit" so existing deployments keep working.
-func hostConfig(cfg DockerPerUserConfig) map[string]any {
+// only attached when set (per-spawn spec or operator CPULimit/MemoryLimit) —
+// a zero value means "no limit" so existing deployments keep working.
+func hostConfig(cfg DockerPerUserConfig, nanoCPUs, memoryBytes int64) map[string]any {
 	hc := map[string]any{
 		"RestartPolicy": map[string]any{"Name": "no"},
 		"NetworkMode":   cfg.Network,
 		"AutoRemove":    false,
 	}
-	if cfg.nanoCPUs > 0 {
-		hc["NanoCpus"] = cfg.nanoCPUs
+	if nanoCPUs > 0 {
+		hc["NanoCpus"] = nanoCPUs
 	}
-	if cfg.memoryBytes > 0 {
-		hc["Memory"] = cfg.memoryBytes
+	if memoryBytes > 0 {
+		hc["Memory"] = memoryBytes
 	}
 	return hc
 }
@@ -194,6 +194,30 @@ func (g *DockerPerUserGateway) containerGone(ctx context.Context, name string) b
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode == 404
+}
+
+// containerNanoCPUs reads the container's actual CPU quota from inspect.
+// Containers can differ from the configured default since per-spawn presets
+// (issue #41), so the static cfg value can't be trusted for usage math.
+// Returns 0 (= no limit) when the container is missing or has no quota.
+func (g *DockerPerUserGateway) containerNanoCPUs(ctx context.Context, name string) int64 {
+	resp, err := g.dockerReq(ctx, "GET", "/containers/"+name+"/json", nil)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return 0
+	}
+	var info struct {
+		HostConfig struct {
+			NanoCpus int64 `json:"NanoCpus"`
+		} `json:"HostConfig"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return 0
+	}
+	return info.HostConfig.NanoCpus
 }
 
 // GetGatewayURL returns the container URL. Spawns if not running. Blocks until
@@ -250,10 +274,12 @@ func (g *DockerPerUserGateway) GetGatewayURL(ctx context.Context, userID string)
 // EnsureSpawning creates and starts the user's container if it isn't already
 // running. Idempotent — returns nil if the container exists in any phase.
 //
-// spec is accepted for interface parity with the k8s gateway but ignored here:
-// per-notebook resource presets are a k8s_per_user feature (issue #41), and
-// docker_per_user keeps the single configured CPU/memory limit.
-func (g *DockerPerUserGateway) EnsureSpawning(userID string, _ *ResourceSpec) error {
+// spec sets THIS container's CPU/memory limits (issue #41 presets); nil falls
+// back to the configured CPULimit/MemoryLimit. Like k8s, the size only takes
+// effect on a fresh spawn — an already-running container keeps its limits
+// until the kernel is restarted. Docker has no "request" concept, so the spec
+// maps to limits only.
+func (g *DockerPerUserGateway) EnsureSpawning(userID string, spec *ResourceSpec) error {
 	if userID == "" {
 		return fmt.Errorf("userID empty")
 	}
@@ -310,7 +336,29 @@ func (g *DockerPerUserGateway) EnsureSpawning(userID string, _ *ResourceSpec) er
 		"S3_ENDPOINT=" + g.cfg.MinIOEndpoint,
 	}
 
+	// Per-spawn limits: user-picked spec wins over the configured defaults.
+	// The spec was already validated by the handler, so a parse failure here
+	// just falls back to the defaults instead of failing the spawn.
+	nanoCPUs, memoryBytes := g.cfg.nanoCPUs, g.cfg.memoryBytes
+	cpuStr, memStr := g.cfg.CPULimit, g.cfg.MemoryLimit
+	if spec != nil && spec.CPU != "" && spec.Memory != "" {
+		if q, err := resource.ParseQuantity(spec.CPU); err == nil {
+			nanoCPUs = q.MilliValue() * 1_000_000
+			cpuStr = spec.CPU
+		}
+		if q, err := resource.ParseQuantity(spec.Memory); err == nil {
+			memoryBytes = q.Value()
+			memStr = spec.Memory
+		}
+	}
+
 	g.upsertRow(userID, name, "", PhaseSpawning, "Creating kernel container")
+	// Record the limits this container was created with (docker has no
+	// requests, so the request columns mirror the limits).
+	database.GetDB().Exec(
+		`UPDATE user_kernel_pods SET cpu_request = $1, mem_request = $2, cpu_limit = $1, mem_limit = $2 WHERE user_id = $3`,
+		cpuStr, memStr, userID,
+	)
 
 	cfg := map[string]any{
 		"Image": g.cfg.Image,
@@ -320,7 +368,7 @@ func (g *DockerPerUserGateway) EnsureSpawning(userID string, _ *ResourceSpec) er
 			"sparklabx.user":   userID,
 		},
 		"ExposedPorts": map[string]any{"8888/tcp": map[string]any{}},
-		"HostConfig": hostConfig(g.cfg),
+		"HostConfig": hostConfig(g.cfg, nanoCPUs, memoryBytes),
 	}
 	if err := g.containerCreate(ctx, name, cfg); err != nil {
 		g.updatePhase(userID, PhaseFailed, err.Error())
@@ -498,10 +546,12 @@ func (g *DockerPerUserGateway) Usage(ctx context.Context, userID string) (Resour
 	// Express as a percentage of the container's OWN quota so 100% = "using
 	// the whole limit" (consistent with how RAM is shown vs its limit). With
 	// a 2-core limit this caps near 100% instead of the confusing 200% a raw
-	// docker-stats percentage would show. Falls back to %-of-host when the
-	// container has no CPU limit.
+	// docker-stats percentage would show. The quota is read from the container
+	// itself (inspect), not the static config — per-spawn presets (issue #41)
+	// mean each container can have its own limit. Falls back to %-of-host when
+	// the container has no CPU limit.
 	cpuPct := 0.0
-	limitCores := float64(g.cfg.nanoCPUs) / 1e9
+	limitCores := float64(g.containerNanoCPUs(ctx, name)) / 1e9
 	if limitCores <= 0 {
 		limitCores = float64(cpus)
 	}

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -337,7 +337,7 @@ func (g *K8sPerUserGateway) GetGatewayURL(ctx context.Context, userID string) (s
 	if err := g.EnsureSpawning(userID, nil); err != nil {
 		return "", err
 	}
-	url, spawnErr := g.spawnAndWait(ctx, userID, podName)
+	url, spawnErr := g.spawnAndWait(ctx, userID, podName, g.rowSizes(userID))
 	if spawnErr != nil {
 		g.updatePhase(userID, PhaseFailed, spawnErr.Error())
 		return "", spawnErr
@@ -361,7 +361,7 @@ func (g *K8sPerUserGateway) EnsureSpawning(userID string, spec *ResourceSpec) er
 	}
 	db := database.GetDB()
 	podName := podNameForUser(userID)
-	cpuReq, memReq, cpuLim, memLim := g.resolveSpec(spec)
+	sizes := g.resolveSpec(spec)
 
 	var dbStatus, dbURL string
 	err := db.QueryRow(
@@ -406,18 +406,22 @@ func (g *K8sPerUserGateway) EnsureSpawning(userID string, spec *ResourceSpec) er
 		 VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8, $9, $10)
 		 ON CONFLICT (user_id) DO UPDATE SET status = $4, phase_message = $5, created_at = $6, last_used_at = $6, pod_url = '', cpu_request = $7, mem_request = $8, cpu_limit = $9, mem_limit = $10`,
 		userID, podName, g.cfg.Namespace, PhaseSpawning, "Preparing kernel pod...", time.Now(),
-		cpuReq, memReq, cpuLim, memLim,
+		sizes.cpuReq, sizes.memReq, sizes.cpuLim, sizes.memLim,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)
 	}
 
 	// Detached spawn goroutine. Use background context with explicit deadline so
-	// the spawn outlives the HTTP request that triggered it.
+	// the spawn outlives the HTTP request that triggered it. The resolved
+	// resources are passed DIRECTLY (not re-read from the row inside the
+	// goroutine): a concurrent Destroy — e.g. the resize path destroying the
+	// predecessor — deletes the row asynchronously and can race the read,
+	// silently reverting the pod to default sizes.
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), spawnTimeout+30*time.Second)
 		defer cancel()
-		url, spawnErr := g.spawnAndWait(ctx, userID, podName)
+		url, spawnErr := g.spawnAndWait(ctx, userID, podName, sizes)
 		if spawnErr != nil {
 			g.updatePhase(userID, PhaseFailed, spawnErr.Error())
 			log.Warn().Err(spawnErr).Str("user_id", userID).Msg("background spawn failed")
@@ -441,7 +445,7 @@ func (g *K8sPerUserGateway) EnsureSpawning(userID string, spec *ResourceSpec) er
 //
 // Phase is written to DB on every meaningful transition so FE polling shows
 // "Pulling image…" / "Container starting…" / etc. without guessing.
-func (g *K8sPerUserGateway) spawnAndWait(ctx context.Context, userID, podName string) (string, error) {
+func (g *K8sPerUserGateway) spawnAndWait(ctx context.Context, userID, podName string, res podSizes) (string, error) {
 	pods := g.client.CoreV1().Pods(g.cfg.Namespace)
 
 	// Step 1 — handle terminating predecessor
@@ -455,7 +459,7 @@ func (g *K8sPerUserGateway) spawnAndWait(ctx context.Context, userID, podName st
 	}
 
 	// Step 2 — Create (idempotent)
-	pod := g.buildPodSpec(userID, podName)
+	pod := g.buildPodSpec(userID, podName, res)
 	if _, err := pods.Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return "", fmt.Errorf("pod create: %w", err)
@@ -609,45 +613,49 @@ func derivePhase(p *corev1.Pod) (phase, message string) {
 	return PhaseSpawning, ""
 }
 
-// resolveSpec turns a user-picked *ResourceSpec into the four request/limit
-// strings the pod spec needs. A valid spec applies its CPU/memory as BOTH
-// request and limit (Guaranteed QoS — the user gets exactly what they picked);
-// nil or incomplete falls back to the gateway's configured defaults (which are
-// burstable: a small request with a larger limit).
-func (g *K8sPerUserGateway) resolveSpec(spec *ResourceSpec) (cpuReq, memReq, cpuLim, memLim string) {
-	if spec != nil && spec.CPU != "" && spec.Memory != "" {
-		return spec.CPU, spec.Memory, spec.CPU, spec.Memory
-	}
-	return g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit
+// podSizes carries the resolved request/limit quantities for one pod spawn.
+// Always fully populated (never empty strings — resource.MustParse would
+// panic). Threaded explicitly from EnsureSpawning into the spawn goroutine
+// instead of being re-read from the DB row, which a concurrent Destroy (the
+// resize path destroying the predecessor) can delete mid-spawn, silently
+// reverting the pod to default sizes.
+type podSizes struct {
+	cpuReq, memReq, cpuLim, memLim string
 }
 
-// podResources reads the per-pod resources persisted on the user_kernel_pods
-// row (written by EnsureSpawning). Falls back to gateway defaults when the row
-// is missing the columns (legacy rows) — never returns empty quantities, which
-// would make resource.MustParse panic.
-func (g *K8sPerUserGateway) podResources(userID string) (cpuReq, memReq, cpuLim, memLim string) {
-	cpuReq, memReq, cpuLim, memLim = g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit
+// resolveSpec turns a user-picked *ResourceSpec into the pod's request/limit
+// quantities. A valid spec applies its CPU/memory as BOTH request and limit
+// (Guaranteed QoS — the user gets exactly what they picked); nil or incomplete
+// falls back to the gateway's configured defaults (which are burstable: a
+// small request with a larger limit).
+func (g *K8sPerUserGateway) resolveSpec(spec *ResourceSpec) podSizes {
+	if spec != nil && spec.CPU != "" && spec.Memory != "" {
+		return podSizes{spec.CPU, spec.Memory, spec.CPU, spec.Memory}
+	}
+	return podSizes{g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit}
+}
+
+// rowSizes reads the sizes recorded on the user_kernel_pods row — used by the
+// legacy GetGatewayURL respawn path, which has no user-picked spec, so a
+// respawn keeps the size the user last chose. Falls back to gateway defaults
+// when the row is missing or predates the resource columns.
+func (g *K8sPerUserGateway) rowSizes(userID string) podSizes {
 	var cr, mr, cl, ml string
 	err := database.GetDB().QueryRow(
 		`SELECT cpu_request, mem_request, cpu_limit, mem_limit FROM user_kernel_pods WHERE user_id = $1`,
 		userID,
 	).Scan(&cr, &mr, &cl, &ml)
-	if err != nil {
-		return
+	if err == nil && cr != "" && mr != "" && cl != "" && ml != "" {
+		return podSizes{cr, mr, cl, ml}
 	}
-	if cr != "" && mr != "" && cl != "" && ml != "" {
-		cpuReq, memReq, cpuLim, memLim = cr, mr, cl, ml
-	}
-	return
+	return podSizes{g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit}
 }
 
-func (g *K8sPerUserGateway) buildPodSpec(userID, podName string) *corev1.Pod {
+func (g *K8sPerUserGateway) buildPodSpec(userID, podName string, res podSizes) *corev1.Pod {
 	// Resolve per-user MinIO creds. Empty creds → fall back to root creds via
 	// SecretKeyRef (legacy / IAM-not-configured). Per-user creds are injected
 	// as plain env values; the pod is per-user and ephemeral so leakage risk
 	// is bounded to the pod's lifetime.
-	cpuReq, memReq, cpuLim, memLim := g.podResources(userID)
-
 	var (
 		userAccessKey, userSecretKey string
 		usePerUserCreds              bool
@@ -716,12 +724,12 @@ func (g *K8sPerUserGateway) buildPodSpec(userID, podName string) *corev1.Pod {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(cpuReq),
-							corev1.ResourceMemory: resource.MustParse(memReq),
+							corev1.ResourceCPU:    resource.MustParse(res.cpuReq),
+							corev1.ResourceMemory: resource.MustParse(res.memReq),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(cpuLim),
-							corev1.ResourceMemory: resource.MustParse(memLim),
+							corev1.ResourceCPU:    resource.MustParse(res.cpuLim),
+							corev1.ResourceMemory: resource.MustParse(res.memLim),
 						},
 					},
 					// Spark s3a reads these from env to build core-site.xml / spark-defaults
@@ -805,12 +813,16 @@ func (g *K8sPerUserGateway) Destroy(userID string) error {
 	}
 
 	// Background: wait for pod fully gone, then drop the row so the next spawn
-	// from this user starts cleanly without bumping into the terminating-handshake path.
+	// from this user starts cleanly without bumping into the terminating-handshake
+	// path. Guarded on status=terminating: the resize flow calls Destroy and then
+	// immediately EnsureSpawning, which inserts a fresh spawning row (with the
+	// newly picked sizes) — an unconditional delete here would race that insert
+	// and wipe the new row mid-spawn.
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 		_ = g.waitForGone(ctx, podName, 90*time.Second)
-		db.Exec(`DELETE FROM user_kernel_pods WHERE user_id = $1`, userID)
+		db.Exec(`DELETE FROM user_kernel_pods WHERE user_id = $1 AND status = $2`, userID, PhaseTerminating)
 		log.Info().Str("user_id", userID).Str("pod", podName).Msg("terminating handshake complete")
 	}()
 	return nil

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -332,7 +332,9 @@ func (g *K8sPerUserGateway) GetGatewayURL(ctx context.Context, userID string) (s
 	// briefly. The Connect handler doesn't go through here anymore (it uses
 	// EnsureSpawning + Status to stay non-blocking) so this path is only hit
 	// when something tries to proxy through a dead pod.
-	if err := g.EnsureSpawning(userID); err != nil {
+	// nil spec → fall back to whatever resources are already on the row (or
+	// gateway defaults). This proxy path never originates a user's size choice.
+	if err := g.EnsureSpawning(userID, nil); err != nil {
 		return "", err
 	}
 	url, spawnErr := g.spawnAndWait(ctx, userID, podName)
@@ -353,12 +355,13 @@ func (g *K8sPerUserGateway) GetGatewayURL(ctx context.Context, userID string) (s
 // EnsureSpawning kicks off pod spawn in a goroutine if no spawn is in flight
 // and pod isn't already ready. Returns immediately. Idempotent: safe to call
 // many times — only the first call from a fresh state triggers actual work.
-func (g *K8sPerUserGateway) EnsureSpawning(userID string) error {
+func (g *K8sPerUserGateway) EnsureSpawning(userID string, spec *ResourceSpec) error {
 	if userID == "" {
 		return fmt.Errorf("userID is required")
 	}
 	db := database.GetDB()
 	podName := podNameForUser(userID)
+	cpuReq, memReq, cpuLim, memLim := g.resolveSpec(spec)
 
 	var dbStatus, dbURL string
 	err := db.QueryRow(
@@ -395,11 +398,15 @@ func (g *K8sPerUserGateway) EnsureSpawning(userID string) error {
 	}
 
 	// Insert spawning row — ON CONFLICT serializes concurrent EnsureSpawning calls.
+	// The resolved resources are persisted on the row so buildPodSpec (which runs
+	// in the detached goroutine) and any later respawn use the size the user
+	// picked for THIS spawn, not the cluster default.
 	_, err = db.Exec(
-		`INSERT INTO user_kernel_pods (user_id, pod_name, pod_namespace, status, phase_message, created_at, last_used_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $6)
-		 ON CONFLICT (user_id) DO UPDATE SET status = $4, phase_message = $5, created_at = $6, last_used_at = $6, pod_url = ''`,
+		`INSERT INTO user_kernel_pods (user_id, pod_name, pod_namespace, status, phase_message, created_at, last_used_at, cpu_request, mem_request, cpu_limit, mem_limit)
+		 VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8, $9, $10)
+		 ON CONFLICT (user_id) DO UPDATE SET status = $4, phase_message = $5, created_at = $6, last_used_at = $6, pod_url = '', cpu_request = $7, mem_request = $8, cpu_limit = $9, mem_limit = $10`,
 		userID, podName, g.cfg.Namespace, PhaseSpawning, "Preparing kernel pod...", time.Now(),
+		cpuReq, memReq, cpuLim, memLim,
 	)
 	if err != nil {
 		return fmt.Errorf("db insert: %w", err)
@@ -602,11 +609,45 @@ func derivePhase(p *corev1.Pod) (phase, message string) {
 	return PhaseSpawning, ""
 }
 
+// resolveSpec turns a user-picked *ResourceSpec into the four request/limit
+// strings the pod spec needs. A valid spec applies its CPU/memory as BOTH
+// request and limit (Guaranteed QoS — the user gets exactly what they picked);
+// nil or incomplete falls back to the gateway's configured defaults (which are
+// burstable: a small request with a larger limit).
+func (g *K8sPerUserGateway) resolveSpec(spec *ResourceSpec) (cpuReq, memReq, cpuLim, memLim string) {
+	if spec != nil && spec.CPU != "" && spec.Memory != "" {
+		return spec.CPU, spec.Memory, spec.CPU, spec.Memory
+	}
+	return g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit
+}
+
+// podResources reads the per-pod resources persisted on the user_kernel_pods
+// row (written by EnsureSpawning). Falls back to gateway defaults when the row
+// is missing the columns (legacy rows) — never returns empty quantities, which
+// would make resource.MustParse panic.
+func (g *K8sPerUserGateway) podResources(userID string) (cpuReq, memReq, cpuLim, memLim string) {
+	cpuReq, memReq, cpuLim, memLim = g.cfg.CPURequest, g.cfg.MemoryRequest, g.cfg.CPULimit, g.cfg.MemoryLimit
+	var cr, mr, cl, ml string
+	err := database.GetDB().QueryRow(
+		`SELECT cpu_request, mem_request, cpu_limit, mem_limit FROM user_kernel_pods WHERE user_id = $1`,
+		userID,
+	).Scan(&cr, &mr, &cl, &ml)
+	if err != nil {
+		return
+	}
+	if cr != "" && mr != "" && cl != "" && ml != "" {
+		cpuReq, memReq, cpuLim, memLim = cr, mr, cl, ml
+	}
+	return
+}
+
 func (g *K8sPerUserGateway) buildPodSpec(userID, podName string) *corev1.Pod {
 	// Resolve per-user MinIO creds. Empty creds → fall back to root creds via
 	// SecretKeyRef (legacy / IAM-not-configured). Per-user creds are injected
 	// as plain env values; the pod is per-user and ephemeral so leakage risk
 	// is bounded to the pod's lifetime.
+	cpuReq, memReq, cpuLim, memLim := g.podResources(userID)
+
 	var (
 		userAccessKey, userSecretKey string
 		usePerUserCreds              bool
@@ -675,12 +716,12 @@ func (g *K8sPerUserGateway) buildPodSpec(userID, podName string) *corev1.Pod {
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(g.cfg.CPURequest),
-							corev1.ResourceMemory: resource.MustParse(g.cfg.MemoryRequest),
+							corev1.ResourceCPU:    resource.MustParse(cpuReq),
+							corev1.ResourceMemory: resource.MustParse(memReq),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse(g.cfg.CPULimit),
-							corev1.ResourceMemory: resource.MustParse(g.cfg.MemoryLimit),
+							corev1.ResourceCPU:    resource.MustParse(cpuLim),
+							corev1.ResourceMemory: resource.MustParse(memLim),
 						},
 					},
 					// Spark s3a reads these from env to build core-site.xml / spark-defaults

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -711,6 +711,11 @@ func (g *K8sPerUserGateway) buildPodSpec(userID, podName string, res podSizes) *
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyOnFailure,
+			// Kernels hold no durable state — killing one loses the user's
+			// variables either way, so a long drain buys nothing. The default
+			// 30s grace made every resize/restart sit in "Cleaning up previous
+			// kernel..." for half a minute; 5s keeps that snappy.
+			TerminationGracePeriodSeconds: ptrInt64(5),
 			// imagePullSecrets only attached for private registries (cfg.PullSecret
 			// set via KERNEL_PULL_SECRET env). Public ghcr.io images don't need it.
 			ImagePullSecrets: pullSecretRefs(g.cfg.PullSecret),
@@ -1093,6 +1098,8 @@ func (g *K8sPerUserGateway) sweepOrphanPods() {
 }
 
 // labelSafe sanitizes a string for use as a K8s label value.
+func ptrInt64(v int64) *int64 { return &v }
+
 func labelSafe(s string) string {
 	const max = 63
 	out := make([]byte, 0, len(s))

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -48,7 +48,12 @@ type KernelGateway interface {
 	// block for minutes waiting on image pull. Caller then polls Status to
 	// learn when phase reaches "ready". SharedGateway is a pure no-op since
 	// there's nothing to spawn.
-	EnsureSpawning(userID string) error
+	//
+	// spec sets the pod's CPU/memory for THIS spawn; nil → gateway defaults.
+	// It only takes effect on a fresh spawn — if a pod is already ready or
+	// spawning, the size is fixed until that pod is destroyed (the kernel pod
+	// is per-user, not per-notebook, so resizing means restarting the kernel).
+	EnsureSpawning(userID string, spec *ResourceSpec) error
 
 	// Usage returns live CPU/memory usage of the user's kernel container/pod.
 	// Returns ErrUsageUnsupported when the mode has no per-user container to
@@ -68,6 +73,15 @@ type ResourceUsage struct {
 	CPULimitCores float64 `json:"cpu_limit_cores"` // quota in cores (e.g. 2); 0 = unlimited
 	MemUsedBytes  int64   `json:"mem_used_bytes"`
 	MemLimitBytes int64   `json:"mem_limit_bytes"`
+}
+
+// ResourceSpec is the resolved CPU/memory for a single kernel pod. Both the
+// request and the limit are set to these values (Guaranteed QoS) so a user
+// gets exactly what they picked. Quantities are in k8s format ("1", "500m",
+// "2Gi"). A nil *ResourceSpec means "use the gateway's configured defaults".
+type ResourceSpec struct {
+	CPU    string
+	Memory string
 }
 
 // ErrUsageUnsupported signals that resource usage can't be measured for this
@@ -104,7 +118,7 @@ func (s *SharedGateway) Status(_ string) (PodStatus, error) {
 	// Shared gateway has no spawn step — always ready.
 	return PodStatus{Phase: PhaseReady, Message: "Kernel ready", URL: s.url}, nil
 }
-func (s *SharedGateway) EnsureSpawning(_ string) error { return nil }
+func (s *SharedGateway) EnsureSpawning(_ string, _ *ResourceSpec) error { return nil }
 func (s *SharedGateway) Usage(_ context.Context, _ string) (ResourceUsage, error) {
 	// One shared container for everyone — no per-user figure to report.
 	return ResourceUsage{}, ErrUsageUnsupported

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,7 +4,7 @@ description: Self-hosted Apache Spark notebooks with per-user isolation.
 type: application
 # Chart version (bump on chart changes). App version tracks the backend
 # image tag — keep in sync with the GitHub release.
-version: 0.1.0
+version: 0.2.0
 appVersion: "main"
 home: https://github.com/sparklabx/sparklabx
 sources:

--- a/chart/templates/backend.yaml
+++ b/chart/templates/backend.yaml
@@ -108,6 +108,20 @@ spec:
               value: {{ .Values.kernel.resources.limits.cpu | quote }}
             - name: KERNEL_POD_MEMORY_LIMIT
               value: {{ .Values.kernel.resources.limits.memory | quote }}
+            {{- with .Values.kernel.resources.presets }}
+            # Per-notebook resource presets (k8s_per_user, issue #41). Serialized
+            # to JSON for the backend; empty list disables the picker entirely.
+            - name: KERNEL_RESOURCE_PRESETS
+              value: {{ toJson . | quote }}
+            - name: KERNEL_RESOURCE_DEFAULT_PRESET
+              value: {{ $.Values.kernel.resources.defaultPreset | default "" | quote }}
+            - name: KERNEL_RESOURCE_ALLOW_CUSTOM
+              value: {{ $.Values.kernel.resources.allowCustom | default false | quote }}
+            - name: KERNEL_RESOURCE_CUSTOM_MAX_CPU
+              value: {{ $.Values.kernel.resources.custom.maxCpu | default "" | quote }}
+            - name: KERNEL_RESOURCE_CUSTOM_MAX_MEMORY
+              value: {{ $.Values.kernel.resources.custom.maxMemory | default "" | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           readinessProbe:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,6 +44,33 @@ kernel:
       cpu: 2000m
       memory: 4Gi
 
+    # ── Per-notebook resource presets (k8s_per_user only, issue #41) ──
+    # OPT-IN. While `presets` is empty the Connect dialog shows no size picker
+    # and every pod uses the requests/limits above — i.e. upgrading changes
+    # nothing. Populate `presets` to let users pick a size per kernel session.
+    #
+    # A preset's cpu/memory is applied as BOTH request and limit (Guaranteed
+    # QoS — the user gets exactly what they pick), so size large presets to
+    # what your nodes can actually schedule or pods sit Pending.
+    #
+    # Example (uncomment to enable):
+    # presets:
+    #   - { id: small,  label: "Small",  cpu: "500m", memory: "1Gi" }
+    #   - { id: medium, label: "Medium", cpu: "1",    memory: "2Gi" }
+    #   - { id: large,  label: "Large",  cpu: "2",    memory: "4Gi" }
+    #   - { id: xlarge, label: "XLarge", cpu: "4",    memory: "8Gi" }
+    # defaultPreset: small      # id pre-selected in the dialog
+    # allowCustom: false        # show a "Custom" row with free CPU/memory inputs
+    # custom:
+    #   maxCpu: "8"             # hard ceiling for custom cpu
+    #   maxMemory: "16Gi"       # hard ceiling for custom memory
+    presets: []
+    defaultPreset: ""
+    allowCustom: false
+    custom:
+      maxCpu: ""
+      maxMemory: ""
+
 # ─────────────────────────────────────────────────────────────
 # Pre-pulling image configurations
 # ─────────────────────────────────────────────────────────────

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,26 +44,27 @@ kernel:
       cpu: 2000m
       memory: 4Gi
 
-    # ── Per-notebook resource presets (k8s_per_user only, issue #41) ──
+    # ── Per-session resource presets (issue #41) ──
     # OPT-IN. While `presets` is empty the Connect dialog shows no size picker
     # and every pod uses the requests/limits above — i.e. upgrading changes
     # nothing. Populate `presets` to let users pick a size per kernel session.
     #
-    # A preset's cpu/memory is applied as BOTH request and limit (Guaranteed
-    # QoS — the user gets exactly what they pick), so size large presets to
-    # what your nodes can actually schedule or pods sit Pending.
+    # k8s_per_user: a preset's cpu/memory is applied as BOTH request and limit
+    # (Guaranteed QoS — the user gets exactly what they pick), so size large
+    # presets to what your nodes can actually schedule or pods sit Pending.
+    # docker_per_user: applied as the container's CPU/memory limits.
     #
     # Example (uncomment to enable):
     # presets:
-    #   - { id: small,  label: "Small",  cpu: "500m", memory: "1Gi" }
-    #   - { id: medium, label: "Medium", cpu: "1",    memory: "2Gi" }
-    #   - { id: large,  label: "Large",  cpu: "2",    memory: "4Gi" }
-    #   - { id: xlarge, label: "XLarge", cpu: "4",    memory: "8Gi" }
-    # defaultPreset: small      # id pre-selected in the dialog
+    #   - { id: medium,  label: "Medium",  cpu: "1", memory: "2Gi"  }
+    #   - { id: large,   label: "Large",   cpu: "2", memory: "4Gi"  }
+    #   - { id: xlarge,  label: "XLarge",  cpu: "4", memory: "8Gi"  }
+    #   - { id: 2xlarge, label: "2XLarge", cpu: "8", memory: "16Gi" }
+    # defaultPreset: medium     # id pre-selected in the dialog
     # allowCustom: false        # show a "Custom" row with free CPU/memory inputs
     # custom:
-    #   maxCpu: "8"             # hard ceiling for custom cpu
-    #   maxMemory: "16Gi"       # hard ceiling for custom memory
+    #   maxCpu: "16"            # hard ceiling for custom cpu
+    #   maxMemory: "32Gi"       # hard ceiling for custom memory
     presets: []
     defaultPreset: ""
     allowCustom: false

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,9 +41,8 @@ services:
       - KERNEL_MODE=${KERNEL_MODE:-shared}
       - KERNEL_POD_IMAGE=${KERNEL_POD_IMAGE:-ghcr.io/sparklabx/kernel:latest}
       - KERNEL_DOCKER_NETWORK=${KERNEL_DOCKER_NETWORK:-sparklabx_default}
-      # Per-notebook resource presets (issue #41). Empty → picker hidden.
-      # Pod sizing only applies in k8s_per_user; docker mode shows the picker
-      # but keeps its single configured limit.
+      # Per-session resource presets (issue #41). Empty → picker hidden.
+      # k8s: request=limit on the pod. docker: container CPU/memory limits.
       - KERNEL_RESOURCE_PRESETS=${KERNEL_RESOURCE_PRESETS:-}
       - KERNEL_RESOURCE_DEFAULT_PRESET=${KERNEL_RESOURCE_DEFAULT_PRESET:-}
       - KERNEL_RESOURCE_ALLOW_CUSTOM=${KERNEL_RESOURCE_ALLOW_CUSTOM:-false}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,6 +41,14 @@ services:
       - KERNEL_MODE=${KERNEL_MODE:-shared}
       - KERNEL_POD_IMAGE=${KERNEL_POD_IMAGE:-ghcr.io/sparklabx/kernel:latest}
       - KERNEL_DOCKER_NETWORK=${KERNEL_DOCKER_NETWORK:-sparklabx_default}
+      # Per-notebook resource presets (issue #41). Empty → picker hidden.
+      # Pod sizing only applies in k8s_per_user; docker mode shows the picker
+      # but keeps its single configured limit.
+      - KERNEL_RESOURCE_PRESETS=${KERNEL_RESOURCE_PRESETS:-}
+      - KERNEL_RESOURCE_DEFAULT_PRESET=${KERNEL_RESOURCE_DEFAULT_PRESET:-}
+      - KERNEL_RESOURCE_ALLOW_CUSTOM=${KERNEL_RESOURCE_ALLOW_CUSTOM:-false}
+      - KERNEL_RESOURCE_CUSTOM_MAX_CPU=${KERNEL_RESOURCE_CUSTOM_MAX_CPU:-}
+      - KERNEL_RESOURCE_CUSTOM_MAX_MEMORY=${KERNEL_RESOURCE_CUSTOM_MAX_MEMORY:-}
       - SERVICE_PORT=10000
       - ENVIRONMENT=production
       - LOG_LEVEL=info

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparklabx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
+++ b/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/select';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Loader2, AlertCircle, CheckCircle2, Server, Plus, X } from 'lucide-react';
+import axios from 'axios';
 import { fetchKernelSpecs, fetchResourcePresets, type KernelSpec, type ResourcePresetsResponse } from '@/services/notebookService';
 import { toast } from 'sonner';
 
@@ -46,13 +47,37 @@ interface KernelConnectionDialogProps {
     savedResourceCustom?: { cpu: string; memory: string };
 }
 
-// "500m" → "0.5", "2" → "2" — humanize a k8s CPU quantity for the pill label.
+// "500m" → "0.5", "2" → "2" — humanize a k8s CPU quantity for display.
 function formatCpu(cpu: string): string {
     if (cpu.endsWith('m')) {
         const milli = parseInt(cpu.slice(0, -1), 10);
         if (!Number.isNaN(milli)) return String(milli / 1000);
     }
     return cpu;
+}
+
+// "2Gi" → "2 GB", "512Mi" → "512 MB" — k8s memory quantity to a friendly unit.
+function formatMem(mem: string): string {
+    return mem.replace(/Gi?$/, ' GB').replace(/Mi?$/, ' MB');
+}
+
+// Inverse converters for the Custom inputs, which take plain numbers (cores /
+// GB) instead of raw k8s quantities — typing "3" meaning 3 GB must never reach
+// the backend as 3 bytes, and "3gb" must never be a parse error.
+function coresFromQuantity(q: string): string {
+    if (q.endsWith('m')) {
+        const milli = parseInt(q.slice(0, -1), 10);
+        if (!Number.isNaN(milli)) return String(milli / 1000);
+    }
+    return q;
+}
+function gbFromQuantity(q: string): string {
+    if (q.endsWith('Gi')) return q.slice(0, -2);
+    if (q.endsWith('Mi')) {
+        const mi = parseFloat(q);
+        if (!Number.isNaN(mi)) return String(mi / 1024);
+    }
+    return q;
 }
 
 interface PackagePreset {
@@ -125,6 +150,10 @@ export function KernelConnectionDialog({
     const [selectedResource, setSelectedResource] = useState<string>('');
     const [customCpu, setCustomCpu] = useState<string>('');
     const [customMemory, setCustomMemory] = useState<string>('');
+    // Size of the user's kernel that is ALREADY running, if any. Shown as a
+    // warning: the kernel is per-user, so picking a different size restarts it
+    // for every notebook attached to it.
+    const [runningSize, setRunningSize] = useState<{ cores: number; memGB: number } | null>(null);
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const packageRows = sparkPackages ? sparkPackages.split('\n') : [''];
@@ -141,6 +170,23 @@ export function KernelConnectionDialog({
     useEffect(() => {
         if (!open) return;
         let alive = true;
+        // Best-effort: learn the size of the kernel that's already running so
+        // the dialog can warn that picking a different one restarts it.
+        (async () => {
+            try {
+                const res = await axios.get('/api/v1/kernel/usage', { timeout: 3000 });
+                if (alive && res.data?.available) {
+                    setRunningSize({
+                        cores: res.data.cpu_limit_cores ?? 0,
+                        memGB: (res.data.mem_limit_bytes ?? 0) / 1024 ** 3,
+                    });
+                } else if (alive) {
+                    setRunningSize(null);
+                }
+            } catch {
+                if (alive) setRunningSize(null);
+            }
+        })();
         (async () => {
             const cfg = await fetchResourcePresets();
             if (!alive) return;
@@ -153,8 +199,10 @@ export function KernelConnectionDialog({
                 ids[0];
             setSelectedResource(initial);
             if (savedResourceCustom) {
-                setCustomCpu(savedResourceCustom.cpu);
-                setCustomMemory(savedResourceCustom.memory);
+                // Saved values are k8s quantities ("1500m"/"3Gi") — the inputs
+                // hold plain numbers.
+                setCustomCpu(coresFromQuantity(savedResourceCustom.cpu));
+                setCustomMemory(gbFromQuantity(savedResourceCustom.memory));
             }
         })();
         return () => { alive = false; };
@@ -270,14 +318,32 @@ export function KernelConnectionDialog({
             let resourceCustom: { cpu: string; memory: string } | undefined;
             if (resourceConfig?.enabled) {
                 if (selectedResource === 'custom') {
-                    const cpu = customCpu.trim();
-                    const memory = customMemory.trim();
-                    if (!cpu || !memory) {
-                        toast.error('Enter both CPU and memory for a custom size');
+                    // Inputs are plain numbers: cores and GB. Convert to k8s
+                    // quantities here ("1.5" → "1500m", "3" GB → "3Gi") so users
+                    // never have to know quantity syntax.
+                    const cpuN = parseFloat(customCpu);
+                    const memN = parseFloat(customMemory);
+                    if (!Number.isFinite(cpuN) || cpuN <= 0 || !Number.isFinite(memN) || memN <= 0) {
+                        toast.error('Enter a valid CPU (cores) and memory (GB)');
                         setIsSubmitting(false);
                         return;
                     }
-                    resourceCustom = { cpu, memory };
+                    const maxCpuN = parseFloat(coresFromQuantity(resourceConfig.max_cpu));
+                    if (Number.isFinite(maxCpuN) && maxCpuN > 0 && cpuN > maxCpuN) {
+                        toast.error(`CPU exceeds the allowed max of ${maxCpuN}`);
+                        setIsSubmitting(false);
+                        return;
+                    }
+                    const maxMemN = parseFloat(gbFromQuantity(resourceConfig.max_memory));
+                    if (Number.isFinite(maxMemN) && maxMemN > 0 && memN > maxMemN) {
+                        toast.error(`Memory exceeds the allowed max of ${maxMemN} GB`);
+                        setIsSubmitting(false);
+                        return;
+                    }
+                    resourceCustom = {
+                        cpu: Number.isInteger(cpuN) ? String(cpuN) : `${Math.round(cpuN * 1000)}m`,
+                        memory: `${memN}Gi`,
+                    };
                 } else if (selectedResource) {
                     resourcePreset = selectedResource;
                 }
@@ -383,56 +449,104 @@ export function KernelConnectionDialog({
                     </div>
 
                     {/* Resources — kernel container/pod size (issue #41).
-                        Hidden unless the admin configured presets. Rendered as a
-                        Select to match the Kernel picker above (pill buttons
-                        wrapped awkwardly at this dialog width). */}
+                        Hidden unless the admin configured presets. Vertical
+                        radio list (the pattern Codespaces / Deepnote / JupyterHub
+                        profile lists use): every option and its specs visible at
+                        a glance, selected row highlighted, default badged. */}
                     {resourceConfig?.enabled && resourceConfig.presets.length > 0 && (
                         <div className="space-y-2">
                             <Label className="text-sm font-medium">Resources</Label>
-                            <Select value={selectedResource} onValueChange={setSelectedResource}>
-                                <SelectTrigger className="h-10">
-                                    <SelectValue placeholder="Select a size..." />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {resourceConfig.presets.map((preset) => (
-                                        <SelectItem key={preset.id} value={preset.id} className="text-sm">
-                                            <div className="flex items-center gap-2">
-                                                <span>{preset.label}</span>
-                                                <span className="text-xs text-muted-foreground">
-                                                    {formatCpu(preset.cpu)} CPU · {preset.memory} RAM
+                            <div className="divide-y divide-border overflow-hidden rounded-md border">
+                                {resourceConfig.presets.map((preset) => {
+                                    const active = selectedResource === preset.id;
+                                    return (
+                                        <button
+                                            key={preset.id}
+                                            type="button"
+                                            onClick={() => setSelectedResource(preset.id)}
+                                            className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
+                                                active ? 'bg-primary/5' : 'hover:bg-muted/40'
+                                            }`}
+                                        >
+                                            <span className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                                                active ? 'border-primary' : 'border-muted-foreground/40'
+                                            }`}>
+                                                {active && <span className="h-2 w-2 rounded-full bg-primary" />}
+                                            </span>
+                                            <span className="w-16 shrink-0 text-sm font-medium">{preset.label}</span>
+                                            <span className="text-xs text-muted-foreground">
+                                                {formatCpu(preset.cpu)} vCPU · {formatMem(preset.memory)} RAM
+                                            </span>
+                                            {preset.id === resourceConfig.default_preset && (
+                                                <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                                                    Default
                                                 </span>
+                                            )}
+                                        </button>
+                                    );
+                                })}
+                                {resourceConfig.allow_custom && (
+                                    <div className={selectedResource === 'custom' ? 'bg-primary/5' : ''}>
+                                        <button
+                                            type="button"
+                                            onClick={() => setSelectedResource('custom')}
+                                            className={`flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors ${
+                                                selectedResource === 'custom' ? '' : 'hover:bg-muted/40'
+                                            }`}
+                                        >
+                                            <span className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full border ${
+                                                selectedResource === 'custom' ? 'border-primary' : 'border-muted-foreground/40'
+                                            }`}>
+                                                {selectedResource === 'custom' && <span className="h-2 w-2 rounded-full bg-primary" />}
+                                            </span>
+                                            <span className="w-16 shrink-0 text-sm font-medium">Custom</span>
+                                            <span className="text-xs text-muted-foreground">set CPU &amp; RAM</span>
+                                        </button>
+                                        {selectedResource === 'custom' && (
+                                            <div className="flex items-center gap-4 px-3 pb-2.5 pl-[2.4rem]">
+                                                <div className="flex items-center gap-1.5">
+                                                    <input
+                                                        type="number"
+                                                        min="0.5"
+                                                        step="0.5"
+                                                        className="flex h-8 w-16 rounded-md border border-input bg-background px-2 py-1 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                        placeholder="2"
+                                                        value={customCpu}
+                                                        onChange={(e) => setCustomCpu(e.target.value)}
+                                                    />
+                                                    <span className="text-xs text-muted-foreground">
+                                                        vCPU{resourceConfig.max_cpu && ` (max ${coresFromQuantity(resourceConfig.max_cpu)})`}
+                                                    </span>
+                                                </div>
+                                                <div className="flex items-center gap-1.5">
+                                                    <input
+                                                        type="number"
+                                                        min="1"
+                                                        step="1"
+                                                        className="flex h-8 w-16 rounded-md border border-input bg-background px-2 py-1 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                                        placeholder="4"
+                                                        value={customMemory}
+                                                        onChange={(e) => setCustomMemory(e.target.value)}
+                                                    />
+                                                    <span className="text-xs text-muted-foreground">
+                                                        GB{resourceConfig.max_memory && ` (max ${gbFromQuantity(resourceConfig.max_memory)})`}
+                                                    </span>
+                                                </div>
                                             </div>
-                                        </SelectItem>
-                                    ))}
-                                    {resourceConfig.allow_custom && (
-                                        <SelectItem value="custom" className="text-sm">
-                                            <div className="flex items-center gap-2">
-                                                <span>Custom</span>
-                                                <span className="text-xs text-muted-foreground">set CPU &amp; RAM</span>
-                                            </div>
-                                        </SelectItem>
-                                    )}
-                                </SelectContent>
-                            </Select>
-                            {selectedResource === 'custom' && (
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                        placeholder={`CPU${resourceConfig.max_cpu ? ` (max ${resourceConfig.max_cpu})` : ''} — e.g. 2`}
-                                        value={customCpu}
-                                        onChange={(e) => setCustomCpu(e.target.value)}
-                                    />
-                                    <input
-                                        className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                        placeholder={`Memory${resourceConfig.max_memory ? ` (max ${resourceConfig.max_memory})` : ''} — e.g. 4Gi`}
-                                        value={customMemory}
-                                        onChange={(e) => setCustomMemory(e.target.value)}
-                                    />
-                                </div>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            {runningSize ? (
+                                <p className="text-[10px] text-amber-600 dark:text-amber-400">
+                                    Your kernel is running at {runningSize.cores} vCPU · {runningSize.memGB.toFixed(1)} GB.
+                                    Picking a different size restarts it — all notebooks using this kernel lose their variables.
+                                </p>
+                            ) : (
+                                <p className="text-[10px] text-muted-foreground">
+                                    Changing size restarts the kernel.
+                                </p>
                             )}
-                            <p className="text-[10px] text-muted-foreground">
-                                Changing size restarts the kernel.
-                            </p>
                         </div>
                     )}
 

--- a/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
+++ b/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
@@ -22,7 +22,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { Loader2, AlertCircle, CheckCircle2, Server, Plus, X, Cpu, MemoryStick } from 'lucide-react';
+import { Loader2, AlertCircle, CheckCircle2, Server, Plus, X } from 'lucide-react';
 import { fetchKernelSpecs, fetchResourcePresets, type KernelSpec, type ResourcePresetsResponse } from '@/services/notebookService';
 import { toast } from 'sonner';
 
@@ -44,6 +44,15 @@ interface KernelConnectionDialogProps {
     savedIcebergWarehousePath?: string;
     savedResourcePreset?: string;
     savedResourceCustom?: { cpu: string; memory: string };
+}
+
+// "500m" → "0.5", "2" → "2" — humanize a k8s CPU quantity for the pill label.
+function formatCpu(cpu: string): string {
+    if (cpu.endsWith('m')) {
+        const milli = parseInt(cpu.slice(0, -1), 10);
+        if (!Number.isNaN(milli)) return String(milli / 1000);
+    }
+    return cpu;
 }
 
 interface PackagePreset {
@@ -373,74 +382,56 @@ export function KernelConnectionDialog({
                         )}
                     </div>
 
-                    {/* Resources (k8s_per_user only). Hidden unless the admin
-                        configured presets. */}
+                    {/* Resources — kernel container/pod size (issue #41).
+                        Hidden unless the admin configured presets. Rendered as a
+                        Select to match the Kernel picker above (pill buttons
+                        wrapped awkwardly at this dialog width). */}
                     {resourceConfig?.enabled && resourceConfig.presets.length > 0 && (
                         <div className="space-y-2">
                             <Label className="text-sm font-medium">Resources</Label>
-                            <div className="grid grid-cols-2 gap-2">
-                                {resourceConfig.presets.map((preset) => {
-                                    const active = selectedResource === preset.id;
-                                    return (
-                                        <button
-                                            key={preset.id}
-                                            type="button"
-                                            onClick={() => setSelectedResource(preset.id)}
-                                            className={`flex flex-col items-start gap-1 rounded-md border p-2.5 text-left transition-colors ${
-                                                active
-                                                    ? 'border-primary bg-primary/5 ring-1 ring-primary'
-                                                    : 'border-input hover:bg-muted/50'
-                                            }`}
-                                        >
-                                            <span className="text-sm font-medium">{preset.label}</span>
-                                            <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                                                <span className="flex items-center gap-1"><Cpu className="h-3 w-3" />{preset.cpu}</span>
-                                                <span className="flex items-center gap-1"><MemoryStick className="h-3 w-3" />{preset.memory}</span>
-                                            </span>
-                                        </button>
-                                    );
-                                })}
-                                {resourceConfig.allow_custom && (
-                                    <button
-                                        type="button"
-                                        onClick={() => setSelectedResource('custom')}
-                                        className={`flex flex-col items-start gap-1 rounded-md border p-2.5 text-left transition-colors ${
-                                            selectedResource === 'custom'
-                                                ? 'border-primary bg-primary/5 ring-1 ring-primary'
-                                                : 'border-input hover:bg-muted/50'
-                                        }`}
-                                    >
-                                        <span className="text-sm font-medium">Custom</span>
-                                        <span className="text-[11px] text-muted-foreground">Set CPU &amp; memory</span>
-                                    </button>
-                                )}
-                            </div>
+                            <Select value={selectedResource} onValueChange={setSelectedResource}>
+                                <SelectTrigger className="h-10">
+                                    <SelectValue placeholder="Select a size..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {resourceConfig.presets.map((preset) => (
+                                        <SelectItem key={preset.id} value={preset.id} className="text-sm">
+                                            <div className="flex items-center gap-2">
+                                                <span>{preset.label}</span>
+                                                <span className="text-xs text-muted-foreground">
+                                                    {formatCpu(preset.cpu)} CPU · {preset.memory} RAM
+                                                </span>
+                                            </div>
+                                        </SelectItem>
+                                    ))}
+                                    {resourceConfig.allow_custom && (
+                                        <SelectItem value="custom" className="text-sm">
+                                            <div className="flex items-center gap-2">
+                                                <span>Custom</span>
+                                                <span className="text-xs text-muted-foreground">set CPU &amp; RAM</span>
+                                            </div>
+                                        </SelectItem>
+                                    )}
+                                </SelectContent>
+                            </Select>
                             {selectedResource === 'custom' && (
-                                <div className="flex gap-2">
-                                    <div className="flex-1 space-y-1">
-                                        <Label className="text-[11px] text-muted-foreground">CPU (cores)</Label>
-                                        <input
-                                            className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                            placeholder="e.g. 2 or 1500m"
-                                            value={customCpu}
-                                            onChange={(e) => setCustomCpu(e.target.value)}
-                                        />
-                                    </div>
-                                    <div className="flex-1 space-y-1">
-                                        <Label className="text-[11px] text-muted-foreground">Memory</Label>
-                                        <input
-                                            className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                            placeholder="e.g. 4Gi"
-                                            value={customMemory}
-                                            onChange={(e) => setCustomMemory(e.target.value)}
-                                        />
-                                    </div>
+                                <div className="flex items-center gap-2">
+                                    <input
+                                        className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        placeholder={`CPU${resourceConfig.max_cpu ? ` (max ${resourceConfig.max_cpu})` : ''} — e.g. 2`}
+                                        value={customCpu}
+                                        onChange={(e) => setCustomCpu(e.target.value)}
+                                    />
+                                    <input
+                                        className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                        placeholder={`Memory${resourceConfig.max_memory ? ` (max ${resourceConfig.max_memory})` : ''} — e.g. 4Gi`}
+                                        value={customMemory}
+                                        onChange={(e) => setCustomMemory(e.target.value)}
+                                    />
                                 </div>
                             )}
                             <p className="text-[10px] text-muted-foreground">
-                                {resourceConfig.allow_custom && (resourceConfig.max_cpu || resourceConfig.max_memory)
-                                    ? `Applies to this kernel; changing it restarts the kernel. Custom max: ${resourceConfig.max_cpu || '∞'} CPU / ${resourceConfig.max_memory || '∞'}.`
-                                    : 'Applies to this kernel; changing it restarts the kernel.'}
+                                Changing size restarts the kernel.
                             </p>
                         </div>
                     )}

--- a/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
+++ b/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
@@ -22,8 +22,8 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { Loader2, AlertCircle, CheckCircle2, Server, Plus, X } from 'lucide-react';
-import { fetchKernelSpecs, type KernelSpec } from '@/services/notebookService';
+import { Loader2, AlertCircle, CheckCircle2, Server, Plus, X, Cpu, MemoryStick } from 'lucide-react';
+import { fetchKernelSpecs, fetchResourcePresets, type KernelSpec, type ResourcePresetsResponse } from '@/services/notebookService';
 import { toast } from 'sonner';
 
 // ... (previous code)
@@ -37,9 +37,13 @@ interface KernelConnectionDialogProps {
         kernelName?: string;
         sparkPackages?: string;
         icebergWarehousePath?: string;
+        resourcePreset?: string;
+        resourceCustom?: { cpu: string; memory: string };
     }) => Promise<void>;
     savedPackages?: string;
     savedIcebergWarehousePath?: string;
+    savedResourcePreset?: string;
+    savedResourceCustom?: { cpu: string; memory: string };
 }
 
 interface PackagePreset {
@@ -95,6 +99,8 @@ export function KernelConnectionDialog({
     onConnect,
     savedPackages,
     savedIcebergWarehousePath,
+    savedResourcePreset,
+    savedResourceCustom,
 }: KernelConnectionDialogProps) {
     // Kernel selection
     const [kernelSpecs, setKernelSpecs] = useState<Record<string, KernelSpec>>({});
@@ -103,6 +109,13 @@ export function KernelConnectionDialog({
     const [sparkPackages, setSparkPackages] = useState<string>('');
     const [activePresetId, setActivePresetId] = useState<string | null>(null);
     const [icebergWarehousePath, setIcebergWarehousePath] = useState<string>('');
+
+    // Resource sizing (k8s_per_user, issue #41). resourceConfig.enabled gates the
+    // whole section. selectedResource is a preset id, or the sentinel 'custom'.
+    const [resourceConfig, setResourceConfig] = useState<ResourcePresetsResponse | null>(null);
+    const [selectedResource, setSelectedResource] = useState<string>('');
+    const [customCpu, setCustomCpu] = useState<string>('');
+    const [customMemory, setCustomMemory] = useState<string>('');
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const packageRows = sparkPackages ? sparkPackages.split('\n') : [''];
@@ -113,6 +126,30 @@ export function KernelConnectionDialog({
             fetchKernelSpecsList();
         }
     }, [open]);
+
+    // Fetch resource presets when dialog opens. Pick the saved preset, else the
+    // configured default, else the first preset. 'custom' only if allowed.
+    useEffect(() => {
+        if (!open) return;
+        let alive = true;
+        (async () => {
+            const cfg = await fetchResourcePresets();
+            if (!alive) return;
+            setResourceConfig(cfg);
+            if (!cfg.enabled || cfg.presets.length === 0) return;
+            const ids = cfg.presets.map(p => p.id);
+            const initial =
+                (savedResourcePreset && (ids.includes(savedResourcePreset) || (savedResourcePreset === 'custom' && cfg.allow_custom)) && savedResourcePreset) ||
+                (cfg.default_preset && ids.includes(cfg.default_preset) && cfg.default_preset) ||
+                ids[0];
+            setSelectedResource(initial);
+            if (savedResourceCustom) {
+                setCustomCpu(savedResourceCustom.cpu);
+                setCustomMemory(savedResourceCustom.memory);
+            }
+        })();
+        return () => { alive = false; };
+    }, [open, savedResourcePreset, savedResourceCustom]);
 
     // Auto-select default kernel based on language
     useEffect(() => {
@@ -218,11 +255,32 @@ export function KernelConnectionDialog({
                 setIsSubmitting(false);
                 return;
             }
+
+            // Resolve the chosen kernel-pod size, if the feature is enabled.
+            let resourcePreset: string | undefined;
+            let resourceCustom: { cpu: string; memory: string } | undefined;
+            if (resourceConfig?.enabled) {
+                if (selectedResource === 'custom') {
+                    const cpu = customCpu.trim();
+                    const memory = customMemory.trim();
+                    if (!cpu || !memory) {
+                        toast.error('Enter both CPU and memory for a custom size');
+                        setIsSubmitting(false);
+                        return;
+                    }
+                    resourceCustom = { cpu, memory };
+                } else if (selectedResource) {
+                    resourcePreset = selectedResource;
+                }
+            }
+
             await onConnect({
                 enableSpark: false, // Explicitly false as per new requirement
                 kernelName: selectedKernelName || undefined,
                 sparkPackages: normalizedPackages || undefined,
                 icebergWarehousePath: icebergWarehousePath.trim() || undefined,
+                resourcePreset,
+                resourceCustom,
             });
             onClose();
         } catch (error) {
@@ -314,6 +372,78 @@ export function KernelConnectionDialog({
                             </div>
                         )}
                     </div>
+
+                    {/* Resources (k8s_per_user only). Hidden unless the admin
+                        configured presets. */}
+                    {resourceConfig?.enabled && resourceConfig.presets.length > 0 && (
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Resources</Label>
+                            <div className="grid grid-cols-2 gap-2">
+                                {resourceConfig.presets.map((preset) => {
+                                    const active = selectedResource === preset.id;
+                                    return (
+                                        <button
+                                            key={preset.id}
+                                            type="button"
+                                            onClick={() => setSelectedResource(preset.id)}
+                                            className={`flex flex-col items-start gap-1 rounded-md border p-2.5 text-left transition-colors ${
+                                                active
+                                                    ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                                                    : 'border-input hover:bg-muted/50'
+                                            }`}
+                                        >
+                                            <span className="text-sm font-medium">{preset.label}</span>
+                                            <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                                                <span className="flex items-center gap-1"><Cpu className="h-3 w-3" />{preset.cpu}</span>
+                                                <span className="flex items-center gap-1"><MemoryStick className="h-3 w-3" />{preset.memory}</span>
+                                            </span>
+                                        </button>
+                                    );
+                                })}
+                                {resourceConfig.allow_custom && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setSelectedResource('custom')}
+                                        className={`flex flex-col items-start gap-1 rounded-md border p-2.5 text-left transition-colors ${
+                                            selectedResource === 'custom'
+                                                ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                                                : 'border-input hover:bg-muted/50'
+                                        }`}
+                                    >
+                                        <span className="text-sm font-medium">Custom</span>
+                                        <span className="text-[11px] text-muted-foreground">Set CPU &amp; memory</span>
+                                    </button>
+                                )}
+                            </div>
+                            {selectedResource === 'custom' && (
+                                <div className="flex gap-2">
+                                    <div className="flex-1 space-y-1">
+                                        <Label className="text-[11px] text-muted-foreground">CPU (cores)</Label>
+                                        <input
+                                            className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            placeholder="e.g. 2 or 1500m"
+                                            value={customCpu}
+                                            onChange={(e) => setCustomCpu(e.target.value)}
+                                        />
+                                    </div>
+                                    <div className="flex-1 space-y-1">
+                                        <Label className="text-[11px] text-muted-foreground">Memory</Label>
+                                        <input
+                                            className="flex h-9 w-full rounded-md border border-input bg-background px-2 py-1 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            placeholder="e.g. 4Gi"
+                                            value={customMemory}
+                                            onChange={(e) => setCustomMemory(e.target.value)}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                            <p className="text-[10px] text-muted-foreground">
+                                {resourceConfig.allow_custom && (resourceConfig.max_cpu || resourceConfig.max_memory)
+                                    ? `Applies to this kernel; changing it restarts the kernel. Custom max: ${resourceConfig.max_cpu || '∞'} CPU / ${resourceConfig.max_memory || '∞'}.`
+                                    : 'Applies to this kernel; changing it restarts the kernel.'}
+                            </p>
+                        </div>
+                    )}
 
                     {/* Spark Packages / JARs */}
                     <div className="space-y-2">

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -770,15 +770,24 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         return false;
     };
 
-    const getStoredKernelProfile = () => ({
-        sparkPackages: ((notebook as any)?.cluster_config?.['spark.jars.packages'] as string | undefined) || undefined,
-        icebergWarehousePath: ((notebook as any)?.cluster_config?.['spark.sql.catalog.iceberg.warehouse'] as string | undefined) || undefined,
-    });
+    const getStoredKernelProfile = () => {
+        const cc = (notebook as any)?.cluster_config || {};
+        const cpu = cc['sparklabx.kernel.resourceCpu'] as string | undefined;
+        const memory = cc['sparklabx.kernel.resourceMemory'] as string | undefined;
+        return {
+            sparkPackages: (cc['spark.jars.packages'] as string | undefined) || undefined,
+            icebergWarehousePath: (cc['spark.sql.catalog.iceberg.warehouse'] as string | undefined) || undefined,
+            resourcePreset: (cc['sparklabx.kernel.resourcePreset'] as string | undefined) || undefined,
+            resourceCustom: cpu && memory ? { cpu, memory } : undefined,
+        };
+    };
 
     const handleKernelDialogConnect = async (options: {
         kernelName?: string;
         sparkPackages?: string;
         icebergWarehousePath?: string;
+        resourcePreset?: string;
+        resourceCustom?: { cpu: string; memory: string };
     }) => {
         if (!notebook) return;
         const existingProfile = getStoredKernelProfile();
@@ -792,6 +801,16 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 }
                 if (nextIcebergWarehousePath) {
                     nextClusterConfig['spark.sql.catalog.iceberg.warehouse'] = nextIcebergWarehousePath;
+                }
+                // Persist the chosen kernel-pod size so the dialog defaults to it
+                // next time (e.g. reconnecting after an idle reap). These keys are
+                // ignored by Spark; only the Connect flow reads them.
+                if (options.resourceCustom) {
+                    nextClusterConfig['sparklabx.kernel.resourcePreset'] = 'custom';
+                    nextClusterConfig['sparklabx.kernel.resourceCpu'] = options.resourceCustom.cpu;
+                    nextClusterConfig['sparklabx.kernel.resourceMemory'] = options.resourceCustom.memory;
+                } else if (options.resourcePreset) {
+                    nextClusterConfig['sparklabx.kernel.resourcePreset'] = options.resourcePreset;
                 }
                 await updateNotebook({ cluster_config: nextClusterConfig });
                 devLog('[NotebookPage] Saved spark packages to notebook config');
@@ -811,7 +830,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
             // shadowing the kernel's lazy `spark` val). Single path now.
             setSparkPackages(options.sparkPackages);
             setIcebergWarehousePath(nextIcebergWarehousePath);
-            connect(lang, options.kernelName);
+            connect(lang, options.kernelName, {
+                preset: options.resourcePreset,
+                custom: options.resourceCustom,
+            });
 
             // Wait for kernel to be fully ready (max 60s). The auto-init effect
             // handles init code injection once the kernel reports connected.
@@ -1875,6 +1897,16 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 onConnect={handleKernelDialogConnect}
                 savedPackages={(notebook as any)?.cluster_config?.['spark.jars.packages'] || ''}
                 savedIcebergWarehousePath={(notebook as any)?.cluster_config?.['spark.sql.catalog.iceberg.warehouse'] || ''}
+                savedResourcePreset={(notebook as any)?.cluster_config?.['sparklabx.kernel.resourcePreset'] || ''}
+                savedResourceCustom={
+                    (notebook as any)?.cluster_config?.['sparklabx.kernel.resourceCpu'] &&
+                    (notebook as any)?.cluster_config?.['sparklabx.kernel.resourceMemory']
+                        ? {
+                              cpu: (notebook as any).cluster_config['sparklabx.kernel.resourceCpu'],
+                              memory: (notebook as any).cluster_config['sparklabx.kernel.resourceMemory'],
+                          }
+                        : undefined
+                }
             />
 
             {/* Create Notebook Dialog */}

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -935,7 +935,11 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
     }, [notebookId]);
 
     // Connect to kernel via Backend API or Kernel Proxy
-    const connect = useCallback(async (language: NotebookLanguage = 'python', kernelName?: string) => {
+    const connect = useCallback(async (
+        language: NotebookLanguage = 'python',
+        kernelName?: string,
+        resources?: { preset?: string; custom?: { cpu: string; memory: string } },
+    ) => {
         try {
             sessionManager.updateSession(notebookId, { status: 'connecting' });
 
@@ -985,12 +989,22 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             const langLower = language.toLowerCase();
             devLog(`[JupyterKernel][${notebookId}] Requesting kernel:`, { language: langLower, kernel_name: kernelName });
 
-            const payload: { tier: string; language: string; kernel_name?: string } = {
-                tier: "medium",
+            const payload: {
+                language: string;
+                kernel_name?: string;
+                resources?: { preset?: string; custom?: { cpu: string; memory: string } };
+            } = {
                 language: langLower
             };
             if (kernelName) {
                 payload.kernel_name = kernelName;
+            }
+            // Per-notebook kernel-pod size (k8s_per_user, issue #41). Omitted when
+            // the dialog didn't set one → backend falls back to cluster defaults.
+            if (resources?.custom) {
+                payload.resources = { custom: resources.custom };
+            } else if (resources?.preset) {
+                payload.resources = { preset: resources.preset };
             }
 
             // Async connect protocol:

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -1099,11 +1099,15 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             // Tell backend to disconnect. Pair with a min-duration
             // delay so the intermediate state stays visible long
             // enough to register on fast (docker-compose) backends
-            // where DELETE often returns in <50ms.
+            // where DELETE often returns in <50ms. The 10s timeout is
+            // load-bearing: without it an unreachable backend (restart,
+            // network blip) leaves the request hanging forever and the
+            // "Disconnecting…" badge spinning with it — the local
+            // disconnect below must happen regardless.
             const minVisible = new Promise(r => setTimeout(r, 800));
             try {
                 await Promise.all([
-                    axios.delete(`/api/v1/notebooks/${notebookId}/kernel/disconnect`),
+                    axios.delete(`/api/v1/notebooks/${notebookId}/kernel/disconnect`, { timeout: 10_000 }),
                     minVisible,
                 ]);
             } catch (e) {

--- a/frontend/src/services/notebookService.ts
+++ b/frontend/src/services/notebookService.ts
@@ -482,6 +482,36 @@ export async function fetchKernelSpecs(): Promise<KernelSpecsResponse> {
     return response.data;
 }
 
+// ============ Resource presets (k8s_per_user, issue #41) ============
+
+export interface ResourcePreset {
+    id: string;
+    label: string;
+    cpu: string;
+    memory: string;
+}
+
+export interface ResourcePresetsResponse {
+    enabled: boolean;
+    presets: ResourcePreset[];
+    default_preset: string;
+    allow_custom: boolean;
+    max_cpu: string;
+    max_memory: string;
+}
+
+// Fetch the kernel-pod size presets the admin configured. enabled=false means
+// the deployment has no presets (or isn't k8s_per_user) → hide the picker.
+// Resolves to a disabled response on any error so the dialog still works.
+export async function fetchResourcePresets(): Promise<ResourcePresetsResponse> {
+    try {
+        const response = await api.get<ResourcePresetsResponse>('/api/v1/kernel/resource-presets');
+        return response.data;
+    } catch {
+        return { enabled: false, presets: [], default_preset: '', allow_custom: false, max_cpu: '', max_memory: '' };
+    }
+}
+
 // ============ Export ============
 
 export const notebookService = {
@@ -504,6 +534,7 @@ export const notebookService = {
     // Kernel
     getKernelSession,
     fetchKernelSpecs,
+    fetchResourcePresets,
 
     // WebSocket
     connectNotebookWebSocket,


### PR DESCRIPTION
Closes #41.

## What

Users pick their kernel's CPU/RAM in the Connect Kernel dialog — preset menu (admin-curated in `values.yaml`) plus an optional capped **Custom** row. Works on both `k8s_per_user` (request=limit, Guaranteed QoS) and `docker_per_user` (container NanoCpus/Memory limits).

## How

- **Chart (opt-in)**: `kernel.resources.presets` block; empty list = feature off, zero behavior change on upgrade. Presets serialized to `KERNEL_RESOURCE_PRESETS` env.
- **Backend**: `EnsureSpawning(userID, *ResourceSpec)`; sizes threaded directly into the spawn (not re-read from the DB row — a concurrent Destroy races that read); validated server-side (preset id / quantity / caps / 0.1-core & 128Mi floors); new `GET /api/v1/kernel/resource-presets`; `user_kernel_pods` gains size columns (legacy rows fall back to defaults).
- **Resize-on-connect**: picking a size different from the running kernel destroys + respawns it (semantic quantity compare so the FE poll loop can't restart-loop). Kernel is per-user: notebook B resizing restarts notebook A's kernel too — the dialog shows the running size with an explicit warning.
- **Frontend**: vertical radio list (Codespaces/Deepnote pattern) with specs + Default badge; Custom inputs take plain numbers (cores/GB) converted client-side; choice persisted per notebook.
- **Fixes found along the way**: docker `Usage()` read the CPU quota from static config (wrong once per-container limits exist) → now from inspect; disconnect DELETE had no timeout (spinner could hang forever); kernel pod termination grace 30s → 5s (resize 40s → ~12s).

## Tested

- docker-compose: preset/custom spawn limits exact (inspect), resize medium↔xlarge, validation 400s, no restart loop, usage badge per-container.
- OrbStack k8s: Guaranteed QoS (requests=limits), custom 1500m/3Gi exact, resize 12s e2e, metrics-server usage reports per-pod limits, repeat-connect reuses.

Version bumped to **0.2.0** (chart + frontend).