### PR TITLE
release: #33 library-error UX into v0.2.0

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -224,6 +224,7 @@ func main() {
 			kernelMeta.GET("/spawn-status", localKernelHandler.SpawnStatus)
 			kernelMeta.GET("/usage", localKernelHandler.Usage)
 			kernelMeta.GET("/resource-presets", localKernelHandler.ResourcePresets)
+			kernelMeta.GET("/library-errors", localKernelHandler.LibraryErrors)
 		}
 	}
 

--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -468,6 +469,57 @@ func kernelSizeDiffers(userID string, spec *services.ResourceSpec) bool {
 		return cpu != spec.CPU || mem != spec.Memory
 	}
 	return curCPU.Cmp(newCPU) != 0 || curMem.Cmp(newMem) != 0
+}
+
+// LibraryErrors scans the user's recent kernel logs for Spark/Coursier
+// dependency-resolution failures and returns the offending coordinate(s).
+// Spark prints "unresolved dependency: group#artifact;version: not found" to
+// the JVM stderr (container log), which never reaches the notebook cell — so
+// the frontend can't detect a bad Maven coordinate without this (#33).
+func (h *LocalKernelHandler) LibraryErrors(c *gin.Context) {
+	userID := userIDString(c)
+	if userID == "" {
+		c.JSON(http.StatusOK, gin.H{"failed": []string{}})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 4*time.Second)
+	defer cancel()
+	logs, err := h.gateway.RecentLogs(ctx, userID, 400)
+	if err != nil {
+		// No container / shared mode / unreachable — nothing to report.
+		c.JSON(http.StatusOK, gin.H{"failed": []string{}})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"failed": parseUnresolvedCoordinates(logs)})
+}
+
+// failureLineRe matches the log lines that signal a dependency couldn't be
+// resolved (Spark's Ivy resolver and Coursier/Almond phrase it differently).
+var failureLineRe = regexp.MustCompile(`(?i)unresolved dependenc|not found|failed to (resolve|download)|error downloading|could not find artifact|module not found`)
+
+// coordRe pulls Maven coordinates in either the colon form (group:artifact:version,
+// as users type them) or Ivy's hash/semicolon form (group#artifact;version, as
+// Spark prints them). The captured groups normalize both to group:artifact:version.
+var coordRe = regexp.MustCompile(`([a-zA-Z0-9_.\-]+)[#:]([a-zA-Z0-9_.\-]+)[;:]([a-zA-Z0-9_.\-]+)`)
+
+// parseUnresolvedCoordinates returns the distinct coordinates named on log
+// lines that indicate a resolution failure, normalized to group:artifact:version.
+func parseUnresolvedCoordinates(logs string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, line := range strings.Split(logs, "\n") {
+		if !failureLineRe.MatchString(line) {
+			continue
+		}
+		for _, m := range coordRe.FindAllStringSubmatch(line, -1) {
+			coord := m[1] + ":" + m[2] + ":" + m[3]
+			if !seen[coord] {
+				seen[coord] = true
+				out = append(out, coord)
+			}
+		}
+	}
+	return out
 }
 
 // ResourcePresets serves the configured kernel-pod sizes to the frontend so the

--- a/backend/internal/services/docker_per_user_gateway.go
+++ b/backend/internal/services/docker_per_user_gateway.go
@@ -448,6 +448,52 @@ func (g *DockerPerUserGateway) Destroy(userID string) error {
 	return nil
 }
 
+// RecentLogs returns the last tailLines of the container's stdout+stderr so the
+// handler can scrape Spark/Coursier dependency-resolution failures (#33). The
+// non-TTY Docker log stream is multiplexed (8-byte frame headers); we demux to
+// recover clean text.
+func (g *DockerPerUserGateway) RecentLogs(ctx context.Context, userID string, tailLines int) (string, error) {
+	name := dockerContainerName(userID)
+	resp, err := g.dockerReq(ctx, "GET",
+		fmt.Sprintf("/containers/%s/logs?stdout=1&stderr=1&tail=%d", name, tailLines), nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("docker logs %s: status %d", name, resp.StatusCode)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return demuxDockerStream(raw), nil
+}
+
+// demuxDockerStream strips the 8-byte frame headers Docker prepends to each
+// chunk of a multiplexed (non-TTY) log stream. If the data doesn't look
+// framed (TTY containers), it's returned as-is.
+func demuxDockerStream(b []byte) string {
+	var out []byte
+	for len(b) >= 8 {
+		// header: [stream(1) 0 0 0 size(4 BE)]
+		if b[0] > 2 || b[1] != 0 || b[2] != 0 || b[3] != 0 {
+			// Not a frame header — treat the rest as plain text.
+			out = append(out, b...)
+			break
+		}
+		size := int(b[4])<<24 | int(b[5])<<16 | int(b[6])<<8 | int(b[7])
+		b = b[8:]
+		if size > len(b) {
+			size = len(b)
+		}
+		out = append(out, b[:size]...)
+		b = b[size:]
+	}
+	out = append(out, b...)
+	return string(out)
+}
+
 // ============================================================
 // Docker REST helpers
 // ============================================================

--- a/backend/internal/services/k8s_per_user_gateway.go
+++ b/backend/internal/services/k8s_per_user_gateway.go
@@ -251,6 +251,19 @@ func (g *K8sPerUserGateway) Usage(ctx context.Context, userID string) (ResourceU
 	return usage, nil
 }
 
+// RecentLogs returns the last tailLines of the user's kernel pod log so the
+// handler can scrape Spark/Coursier dependency-resolution failures (#33).
+func (g *K8sPerUserGateway) RecentLogs(ctx context.Context, userID string, tailLines int) (string, error) {
+	podName := podNameForUser(userID)
+	tl := int64(tailLines)
+	req := g.client.CoreV1().Pods(g.cfg.Namespace).GetLogs(podName, &corev1.PodLogOptions{TailLines: &tl})
+	raw, err := req.DoRaw(ctx)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
 // podNameForUser returns a DNS-safe, deterministic pod name for a user ID.
 func podNameForUser(userID string) string {
 	h := sha1.Sum([]byte(userID))

--- a/backend/internal/services/kernel_gateway.go
+++ b/backend/internal/services/kernel_gateway.go
@@ -61,6 +61,14 @@ type KernelGateway interface {
 	// metrics-server) — callers should treat that as "hide the widget", not
 	// a hard error.
 	Usage(ctx context.Context, userID string) (ResourceUsage, error)
+
+	// RecentLogs returns the last `tailLines` of the user's kernel
+	// container/pod stdout+stderr. Used to surface dependency-resolution
+	// failures (issue #33): Spark/Coursier print "unresolved dependency …"
+	// to the JVM's stderr, which lands in the container log — NOT in the
+	// notebook cell — so the UI can't see it without reading the log here.
+	// Returns ErrUsageUnsupported for SharedGateway (no per-user container).
+	RecentLogs(ctx context.Context, userID string, tailLines int) (string, error)
 }
 
 // ResourceUsage is a point-in-time snapshot of a kernel container/pod's
@@ -129,6 +137,9 @@ func (s *SharedGateway) EnsureSpawning(_ string, _ *ResourceSpec) error { return
 func (s *SharedGateway) Usage(_ context.Context, _ string) (ResourceUsage, error) {
 	// One shared container for everyone — no per-user figure to report.
 	return ResourceUsage{}, ErrUsageUnsupported
+}
+func (s *SharedGateway) RecentLogs(_ context.Context, _ string, _ int) (string, error) {
+	return "", ErrUsageUnsupported
 }
 
 // KernelGatewaySettings is the fully-resolved config needed to build a gateway.

--- a/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
+++ b/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
@@ -592,17 +592,19 @@ export function KernelConnectionDialog({
                                         value={pkg}
                                         onChange={(e) => updatePackageRow(index, e.target.value)}
                                     />
-                                    {pkg.trim() && (
-                                        <Button
-                                            type="button"
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 shrink-0 text-muted-foreground"
-                                            onClick={() => removePackageRow(index)}
-                                        >
-                                            <X className="h-4 w-4" />
-                                        </Button>
-                                    )}
+                                    {/* Always render the slot so the input doesn't
+                                        rescale when the X appears on paste. */}
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        aria-hidden={!pkg.trim()}
+                                        tabIndex={pkg.trim() ? 0 : -1}
+                                        className={`h-8 w-8 shrink-0 text-muted-foreground ${pkg.trim() ? '' : 'invisible pointer-events-none'}`}
+                                        onClick={() => removePackageRow(index)}
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </Button>
                                 </div>
                             ))}
                             <Button

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -770,55 +770,45 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         return false;
     };
 
-    // Scan the spark-init cell output for dependency-resolution failures
-    // (Coursier/Ivy). A bad Maven coordinate makes getOrCreate() (PySpark) or
-    // `import $ivy` (Almond) throw, and the resolver prints "not found" /
-    // "Failed to resolve" into the init cell — but nothing surfaces in the UI.
-    // Returns the failing coordinate(s), or null when resolution looks clean.
-    // Issue #33.
-    const detectLibraryResolutionErrors = (): string[] | null => {
-        const outs = cellOutputsRef.current['init-spark-context'] || [];
-        const text = (outs as any[])
-            .map(o => o?.text ? String(o.text)
-                : o?.ename ? `${o.ename}: ${o.evalue}\n${(o.traceback || []).join('\n')}`
-                : JSON.stringify(o?.data ?? ''))
-            .join('\n');
-        const FAIL_RE = /(failed to resolve|error downloading|not found:|failed to download|resolutionexception|unresolved dependenc|could not find artifact)/i;
-        if (!FAIL_RE.test(text)) return null;
-
-        // Pull group:artifact:version tokens off the lines that mention a failure.
-        const coordRe = /[a-zA-Z0-9_.\-]+:[a-zA-Z0-9_.\-]+:[a-zA-Z0-9_.\-]+/g;
-        const failed = new Set<string>();
-        for (const line of text.split('\n')) {
-            if (FAIL_RE.test(line)) (line.match(coordRe) || []).forEach(c => failed.add(c));
+    // Ask the backend which coordinates failed to resolve. Spark/Coursier print
+    // "unresolved dependency: group#artifact;version: not found" to the JVM
+    // stderr → container log, which never reaches the notebook cell, so the
+    // backend reads the kernel log and parses the offending coords (#33). The
+    // pod log accumulates across in-pod restarts, so we intersect with the
+    // coordinates we just requested — stale failures from earlier attempts (a
+    // version the user already corrected) must not be re-reported.
+    const fetchLibraryErrors = async (requested: string[]): Promise<string[]> => {
+        try {
+            const res = await axios.get<{ failed: string[] }>('/api/v1/kernel/library-errors', { timeout: 5000 });
+            const all = res.data?.failed || [];
+            if (!requested.length) return all;
+            const want = new Set(requested);
+            return all.filter(c => want.has(c));
+        } catch {
+            return [];
         }
-        // Fallback: failure detected but no coordinate parsed → blame the whole
-        // requested set so the user at least knows where to look.
-        if (failed.size === 0) {
-            const requested = (sparkPackages || (notebook as any)?.cluster_config?.['spark.jars.packages'] || '')
-                .split(/[,\n]/).map((p: string) => p.trim()).filter(Boolean);
-            requested.forEach((p: string) => failed.add(p));
-        }
-        return failed.size ? Array.from(failed) : null;
     };
 
     // Surface the outcome of a library load (after the spark-init cell settles).
-    // Shared by the connect flow and Manage Libraries → Apply & Restart.
-    const reportLibraryOutcome = (initOk: boolean, requestedCount: number) => {
-        const failed = detectLibraryResolutionErrors();
-        if (failed && failed.length) {
+    // Shared by the connect flow and Manage Libraries → Apply & Restart. When
+    // init failed, give the JVM a moment to flush the resolver error to its log
+    // before reading it back.
+    const reportLibraryOutcome = async (initOk: boolean, requested: string[]): Promise<boolean> => {
+        if (!initOk) await new Promise(r => setTimeout(r, 600));
+        const failed = await fetchLibraryErrors(requested);
+        if (failed.length) {
             toast.error(`Failed to load ${failed.length} ${failed.length === 1 ? 'library' : 'libraries'}`, {
-                description: `${failed.join(', ')} — check the coordinate exists on Maven Central (repo1.maven.org).`,
-                duration: 12000,
+                description: `${failed.join(', ')} — not found on Maven Central. Check the coordinate and version.`,
+                duration: 14000,
             });
             return false;
         }
         if (!initOk) {
-            toast.error('Spark initialization timed out');
+            toast.error('Spark failed to start — check the library coordinates and try again.');
             return false;
         }
-        if (requestedCount > 0) {
-            toast.success(`Loaded ${requestedCount} ${requestedCount === 1 ? 'library' : 'libraries'}`);
+        if (requested.length > 0) {
+            toast.success(`Loaded ${requested.length} ${requested.length === 1 ? 'library' : 'libraries'}`);
         }
         return true;
     };
@@ -904,9 +894,9 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
             devLog('[NotebookPage] Kernel ready!');
             // If libraries were requested, report load success/failure (#33);
             // otherwise just confirm the connection.
-            const requestedCount = packageListFromInput(options.sparkPackages || '').length;
-            if (requestedCount > 0) {
-                const ok = reportLibraryOutcome(sparkInitReady, requestedCount);
+            const requestedPkgs = packageListFromInput(options.sparkPackages || '');
+            if (requestedPkgs.length > 0) {
+                const ok = await reportLibraryOutcome(sparkInitReady, requestedPkgs);
                 if (ok) toast.success('Kernel connected');
             } else if (!sparkInitReady) {
                 toast.error('Spark initialization timed out');
@@ -2155,7 +2145,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 const back = await waitForReady(60000);
                                 if (back) {
                                     const initOk = await waitForSparkInitCompletion();
-                                    reportLibraryOutcome(initOk, packageListFromInput(packages).length);
+                                    await reportLibraryOutcome(initOk, packageListFromInput(packages));
                                 } else {
                                     toast.error('Kernel did not come back after restart');
                                 }

--- a/frontend/src/components/Notebooks/NotebookPage.tsx
+++ b/frontend/src/components/Notebooks/NotebookPage.tsx
@@ -204,6 +204,11 @@ export default function NotebookPage() {
     const [libraryInput, setLibraryInput] = useState('');
     const libraryRows = libraryInput ? libraryInput.split('\n') : [''];
     const [sparkInitPending, setSparkInitPending] = useState(false);
+    // Spark init ran but FAILED (almost always a bad library coordinate). The
+    // kernel process is still alive — we keep it for a fast fix-and-retry — but
+    // it has no usable `spark`, so we don't show a green "Connected": the badge
+    // reads "Spark not ready" and Spark cells are blocked until it's fixed.
+    const [sparkFailed, setSparkFailed] = useState(false);
     const [sparkInitLogsOpen, setSparkInitLogsOpen] = useState(false);
 
     // Monaco instance for global registration
@@ -269,12 +274,14 @@ export default function NotebookPage() {
         if (currentKernelId && currentKernelId === initedKernelId) {
             devLog(`[NotebookPage] Skipping Spark init — kernel ${currentKernelId} already initialized`);
             setSparkInitPending(false);
+            setSparkFailed(false);
             return;
         }
 
         void (async () => {
             // Block user execution immediately on connect; init may take a while (first run downloads jars).
             setSparkInitPending(true);
+            setSparkFailed(false); // fresh attempt — clear any prior failure state
 
             // If a previous kernel session left outputs for init-spark-context around,
             // `waitForSparkInitCompletion()` could incorrectly return "ready" immediately.
@@ -607,7 +614,10 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
 
                 const initTimeoutMs = packages ? 300000 : 180000; // allow extra time for first-time jar downloads
                 let ok = await waitForSparkInitCompletion(initTimeoutMs);
-                if (!ok && !cancelled) {
+                // Only the genuine "still downloading" case warrants a retry. A
+                // detected failure (resolution error / cell error) is terminal —
+                // retrying it would just re-spin "Booting Spark…" for minutes.
+                if (!ok && !cancelled && !scanInitCellErrors([]).errored) {
                     const stillRunning = runningCellsRef.current.has('init-spark-context');
                     if (stillRunning) {
                         toast.warning('Spark is still initializing…', { description: 'This can take a few minutes the first time.' });
@@ -617,23 +627,40 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 }
 
                 if (!cancelled) {
-                    const stillRunning = runningCellsRef.current.has('init-spark-context');
-                    // If still running, keep the initializing indicator on.
-                    setSparkInitPending(!ok && stillRunning);
-                    if (!ok && !stillRunning) toast.error('Spark initialization timed out');
+                    // Terminal: the init attempt is over (succeeded or failed) and
+                    // the kernel process is alive either way, so always clear the
+                    // "Booting Spark…" badge — never leave it spinning on a failure.
+                    setSparkInitPending(false);
+                    // Reflect failure honestly: connected-but-no-spark is useless
+                    // on a Spark platform, so flag it rather than show "Connected".
+                    setSparkFailed(!ok);
                     if (ok) {
-                        setSparkInitPending(false);
-                        // Remember which kernel pod we successfully
-                        // initialized so a tab reload (same pod)
-                        // skips re-init.
+                        // Remember which kernel pod we successfully initialized so
+                        // a tab reload (same pod) skips re-init.
                         const k = localStorage.getItem(`sparklabx_kernel_${notebookId}`);
                         if (k) localStorage.setItem(`sparklabx_spark_inited_${notebookId}`, k);
+                    }
+                    // Report the library-load outcome from the ONE place that
+                    // actually runs the init cell (covers fresh connect AND
+                    // Apply & Restart, no duplicate toasts).
+                    const requested = packageListFromInput(packages);
+                    if (requested.length > 0) {
+                        void reportLibraryOutcome(ok, requested);
+                    } else if (!ok) {
+                        toast.error('Spark initialization timed out');
                     }
                 }
             }
         })();
         return () => { cancelled = true; };
-    }, [connectionStatus, notebookId, notebookLanguage, sparkPackages, icebergWarehousePath, executeCell, clearCellOutput]);
+        // sparkPackages / icebergWarehousePath are intentionally NOT deps: init
+        // must run once per kernel (re)connect, reading the current packages via
+        // closure at that transition — keeping them as deps re-ran init on the
+        // OLD kernel the moment packages changed (before Apply & Restart's
+        // restart), racing the marker and double-reporting. connectionStatus
+        // cycles on every connect/restart, so fresh packages are always picked up.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connectionStatus, notebookId, notebookLanguage, executeCell, clearCellOutput]);
 
 
 
@@ -735,6 +762,16 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         const start = Date.now();
         let sawInitRunning = false;
 
+        // A dependency-resolution failure (Scala's `import $ivy` runs BEFORE the
+        // init template's try/catch, so it never prints the ❌ marker) or any
+        // cell error is terminal — bail immediately instead of polling to the
+        // timeout, which left the "Booting Spark…" badge spinning for minutes.
+        // Keep this STRICT: these phrases appear only in the FINAL failure
+        // summary. A bare "not found" shows up mid-resolution while Ivy probes
+        // repos for a coordinate it ultimately DOES find, so matching it here
+        // would false-fail a good package.
+        const FAIL_RE = /unresolved dependenc|module not found|resolutionexception|::\s*unresolved/i;
+
         while (Date.now() - start < timeoutMs) {
             const running = runningCellsRef.current;
             const initOutputs = cellOutputsRef.current['init-spark-context'];
@@ -744,8 +781,15 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 sawInitRunning = true;
             }
 
+            let hasError = false;
             const flatText = (initOutputs || [])
-                .map((o: any) => (o?.text ? String(o.text) : JSON.stringify(o?.data ?? '')))
+                .map((o: any) => {
+                    if (o?.type === 'error' || o?.ename) {
+                        hasError = true;
+                        return `${o.ename || ''} ${o.evalue || ''}\n${(o.traceback || []).join('\n')}`;
+                    }
+                    return o?.text ? String(o.text) : JSON.stringify(o?.data ?? '');
+                })
                 .join('\n');
 
             if (flatText.includes('__SPARKLABX_SPARK_READY__') ||
@@ -754,7 +798,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                 return true;
             }
 
-            if (flatText.includes('❌ Spark initialization failed:')) {
+            if (flatText.includes('❌ Spark initialization failed:') || hasError || FAIL_RE.test(flatText)) {
                 return false;
             }
 
@@ -789,26 +833,71 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
         }
     };
 
+    // Scan the spark-init cell for a resolution failure. This is the Scala/
+    // Almond path: `import $ivy` resolves IN-PROCESS, so the error lands in the
+    // cell (an `error` output) — not the pod log — and it fails before the init
+    // template's ✅/❌ markers, so waitForSparkInitCompletion can't see it.
+    // Returns whether the cell errored and any coordinate(s) parsed from it.
+    const scanInitCellErrors = (requested: string[]): { errored: boolean; coords: string[] } => {
+        const outs = (cellOutputsRef.current['init-spark-context'] || []) as any[];
+        let errored = false;
+        const parts: string[] = [];
+        for (const o of outs) {
+            if (o?.type === 'error' || o?.ename) {
+                errored = true;
+                parts.push(`${o.ename || ''} ${o.evalue || ''}\n${(o.traceback || []).join('\n')}`);
+            } else if (o?.text) {
+                parts.push(String(o.text));
+            }
+        }
+        const text = parts.join('\n');
+        const FAIL_RE = /(failed to resolve|not found|error downloading|unresolved|resolutionexception|could not (find|download)|module not found)/i;
+        if (FAIL_RE.test(text)) errored = true;
+        const coordRe = /([a-zA-Z0-9_.\-]+)[#:]([a-zA-Z0-9_.\-]+)[;:]([a-zA-Z0-9_.\-]+)/g;
+        const coords = new Set<string>();
+        for (const line of text.split('\n')) {
+            if (!FAIL_RE.test(line)) continue;
+            let m: RegExpExecArray | null;
+            coordRe.lastIndex = 0;
+            while ((m = coordRe.exec(line))) coords.add(`${m[1]}:${m[2]}:${m[3]}`);
+        }
+        let arr = [...coords];
+        if (requested.length) arr = arr.filter(c => requested.includes(c));
+        return { errored, coords: arr };
+    };
+
     // Surface the outcome of a library load (after the spark-init cell settles).
-    // Shared by the connect flow and Manage Libraries → Apply & Restart. When
-    // init failed, give the JVM a moment to flush the resolver error to its log
-    // before reading it back.
+    // Shared by the connect flow and Manage Libraries → Apply & Restart. Checks
+    // BOTH sources — the kernel log (PySpark, JVM stderr) and the init cell
+    // (Scala/Almond, in-process Coursier) — since each kernel surfaces the
+    // failure in a different place. Falls back to naming the requested packages
+    // when a failure is detected but no coordinate could be parsed.
     const reportLibraryOutcome = async (initOk: boolean, requested: string[]): Promise<boolean> => {
         if (!initOk) await new Promise(r => setTimeout(r, 600));
-        const failed = await fetchLibraryErrors(requested);
+        const fromLogs = await fetchLibraryErrors(requested);
+        const cell = scanInitCellErrors(requested);
+        let failed = Array.from(new Set([...fromLogs, ...cell.coords]));
+        // A failure happened (cell errored, init never reached ready, or coords
+        // found) but we couldn't pin the coordinate → blame the requested set.
+        const failureDetected = failed.length > 0 || cell.errored || !initOk;
+        if (failed.length === 0 && failureDetected && requested.length) {
+            failed = [...requested];
+        }
         if (failed.length) {
+            // Stable id → a residual double-call replaces rather than stacks.
             toast.error(`Failed to load ${failed.length} ${failed.length === 1 ? 'library' : 'libraries'}`, {
+                id: 'kernel-library-outcome',
                 description: `${failed.join(', ')} — not found on Maven Central. Check the coordinate and version.`,
                 duration: 14000,
             });
             return false;
         }
         if (!initOk) {
-            toast.error('Spark failed to start — check the library coordinates and try again.');
+            toast.error('Spark failed to start — check the library coordinates and try again.', { id: 'kernel-library-outcome' });
             return false;
         }
         if (requested.length > 0) {
-            toast.success(`Loaded ${requested.length} ${requested.length === 1 ? 'library' : 'libraries'}`);
+            toast.success(`Loaded ${requested.length} ${requested.length === 1 ? 'library' : 'libraries'}`, { id: 'kernel-library-outcome' });
         }
         return true;
     };
@@ -892,16 +981,14 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
             const sparkInitReady = await waitForSparkInitCompletion();
 
             devLog('[NotebookPage] Kernel ready!');
-            // If libraries were requested, report load success/failure (#33);
-            // otherwise just confirm the connection.
+            // The auto-init effect owns library load reporting (success/failure
+            // toast) since it's the path that actually runs the init cell — see
+            // reportLibraryOutcome there. Here we only confirm a clean connect
+            // when no libraries were requested, to avoid a toast race.
             const requestedPkgs = packageListFromInput(options.sparkPackages || '');
-            if (requestedPkgs.length > 0) {
-                const ok = await reportLibraryOutcome(sparkInitReady, requestedPkgs);
-                if (ok) toast.success('Kernel connected');
-            } else if (!sparkInitReady) {
-                toast.error('Spark initialization timed out');
-            } else {
-                toast.success('Kernel connected');
+            if (requestedPkgs.length === 0) {
+                if (sparkInitReady) toast.success('Kernel connected');
+                else toast.error('Spark initialization timed out');
             }
         } catch (error) {
             console.error('Failed to connect:', error);
@@ -1273,6 +1360,15 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
             toast.info('Kernel is still initializing Spark, please wait a few seconds...');
             return;
         }
+        // Spark init failed (bad library) — `spark` doesn't exist, so running a
+        // cell would just throw a confusing NameError. Point the user at the fix.
+        if (sparkFailed) {
+            toast.error('Spark isn\'t ready — a library failed to load.', {
+                description: 'Fix the coordinate and restart the kernel.',
+                action: { label: 'Fix libraries', onClick: () => setLibraryDialogOpen(true) },
+            });
+            return;
+        }
 
         // Flush pending cell update immediately (e.g. code changes)
         if (updateCellTimerRef.current[cellId]) {
@@ -1503,7 +1599,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                             <div className="pt-2">
                                 <div className="text-xs">
                                     <p className="mb-2 text-muted-foreground">Kernel Status:</p>
-                                    <ConnectionStatusBadge status={connectionStatus} deadReason={deadReason} sparkInitializing={sparkInitPending || runningCells.has('init-spark-context')} />
+                                    <ConnectionStatusBadge status={connectionStatus} deadReason={deadReason} sparkInitializing={sparkInitPending || runningCells.has('init-spark-context')} sparkFailed={sparkFailed} />
 
                                     {/* Pod spawn / terminate progress (k8s_per_user mode).
                                         Shown for non-ready phases so user knows the pod is doing
@@ -1694,7 +1790,7 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 }
                             }}
                         >
-                            <ConnectionStatusBadge status={connectionStatus} deadReason={deadReason} compact={compactToolbar} sparkInitializing={sparkInitPending || runningCells.has('init-spark-context')} />
+                            <ConnectionStatusBadge status={connectionStatus} deadReason={deadReason} compact={compactToolbar} sparkInitializing={sparkInitPending || runningCells.has('init-spark-context')} sparkFailed={sparkFailed} />
                         </div>
                     </div>
 
@@ -1753,6 +1849,17 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                         if (isExecuting) {
                                             handleInterrupt();
                                         } else {
+                                            if (sparkInitPending || runningCells.has('init-spark-context')) {
+                                                toast.info('Kernel is still initializing Spark, please wait a few seconds...');
+                                                return;
+                                            }
+                                            if (sparkFailed) {
+                                                toast.error('Spark isn\'t ready — a library failed to load.', {
+                                                    description: 'Fix the coordinate and restart the kernel.',
+                                                    action: { label: 'Fix libraries', onClick: () => setLibraryDialogOpen(true) },
+                                                });
+                                                return;
+                                            }
                                             const sortedCells = [...cells]
                                                 .sort((a, b) => a.order - b.order)
                                                 .map(c => ({ id: c.id, code: c.source, type: c.type }));
@@ -2083,20 +2190,23 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                             setLibraryInput(normalizePackageInput(nextRows.join('\n')));
                                         }}
                                     />
-                                    {pkg.trim() && (
-                                        <Button
-                                            type="button"
-                                            variant="ghost"
-                                            size="icon"
-                                            className="h-8 w-8 shrink-0 text-muted-foreground"
-                                            onClick={() => {
-                                                const nextRows = libraryRows.filter((_, rowIndex) => rowIndex !== index);
-                                                setLibraryInput(normalizePackageInput(nextRows.join('\n')));
-                                            }}
-                                        >
-                                            <X className="h-4 w-4" />
-                                        </Button>
-                                    )}
+                                    {/* Always render the remove-button slot so the
+                                        input width doesn't rescale the moment text is
+                                        pasted (the X used to appear and shrink it). */}
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        aria-hidden={!pkg.trim()}
+                                        tabIndex={pkg.trim() ? 0 : -1}
+                                        className={`h-8 w-8 shrink-0 text-muted-foreground ${pkg.trim() ? '' : 'invisible pointer-events-none'}`}
+                                        onClick={() => {
+                                            const nextRows = libraryRows.filter((_, rowIndex) => rowIndex !== index);
+                                            setLibraryInput(normalizePackageInput(nextRows.join('\n')));
+                                        }}
+                                    >
+                                        <X className="h-4 w-4" />
+                                    </Button>
                                 </div>
                             ))}
                             <Button
@@ -2110,11 +2220,12 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                 Add package
                             </Button>
                         </div>
-                        {packageListFromInput(libraryInput).length > 0 && (
-                            <div className="text-[10px] text-muted-foreground">
-                                {packageListFromInput(libraryInput).length} {packageListFromInput(libraryInput).length === 1 ? 'package' : 'packages'}
-                            </div>
-                        )}
+                        {/* Fixed-height line so the count appearing on paste
+                            doesn't push the footer (no vertical jump). */}
+                        <div className="h-4 text-[10px] text-muted-foreground">
+                            {packageListFromInput(libraryInput).length > 0 &&
+                                `${packageListFromInput(libraryInput).length} ${packageListFromInput(libraryInput).length === 1 ? 'package' : 'packages'}`}
+                        </div>
                     </div>
                     <DialogFooter>
                         <Button variant="outline" onClick={() => setLibraryDialogOpen(false)}>Cancel</Button>
@@ -2133,22 +2244,14 @@ def display(df: org.apache.spark.sql.Dataset[_], n: Int = 20): Unit = {
                                     console.warn('[NotebookPage] Failed to persist package list:', e);
                                 }
                                 // Push into state so the auto-init effect rebuilds init code
-                                // with the new package list once kernel comes back idle.
+                                // with the new package list once the kernel comes back idle.
                                 setSparkPackages(packages);
-                                // In-pod restart — no pod respawn. New SparkSession is built by
-                                // the auto-injected init cell (which reads sparkPackages state)
-                                // when the kernel reports 'connected' again (~1-2s).
-                                clearCellOutput('init-spark-context'); // drop the previous run's output before we scan
+                                clearCellOutput('init-spark-context');
+                                // In-pod restart — no pod respawn. restart() clears the
+                                // "already inited" marker, so when the kernel reports idle
+                                // again the auto-init effect re-runs the init cell with the
+                                // new packages and reports load success/failure itself (#33).
                                 await restart();
-                                // Wait for the fresh init cell to settle, then report whether
-                                // every requested coordinate actually resolved (#33).
-                                const back = await waitForReady(60000);
-                                if (back) {
-                                    const initOk = await waitForSparkInitCompletion();
-                                    await reportLibraryOutcome(initOk, packageListFromInput(packages));
-                                } else {
-                                    toast.error('Kernel did not come back after restart');
-                                }
                             } catch { toast.error('Failed to update libraries'); }
                         }}>
                             Apply & Restart Kernel

--- a/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
+++ b/frontend/src/components/Notebooks/parts/ConnectionStatusBadge.tsx
@@ -7,7 +7,8 @@ export const ConnectionStatusBadge: React.FC<{
     compact?: boolean;
     deadReason?: string;
     sparkInitializing?: boolean;
-}> = ({ status, compact = false, deadReason, sparkInitializing }) => {
+    sparkFailed?: boolean;
+}> = ({ status, compact = false, deadReason, sparkInitializing, sparkFailed }) => {
     const statusConfig: Record<ConnectionStatus, { color: string; label: string; icon?: 'circle' | 'skull' }> = {
         disconnected: { color: 'text-slate-400', label: 'Disconnected' },
         connecting: { color: 'text-blue-500 animate-pulse', label: 'Connecting...' },
@@ -19,10 +20,14 @@ export const ConnectionStatusBadge: React.FC<{
     };
 
     // When kernel is connected but still booting Spark, show a distinct state
-    // so users know why cells are disabled.
-    const config = status === 'connected' && sparkInitializing
-        ? { color: 'text-amber-500 animate-pulse', label: 'Booting Spark...', icon: 'circle' as const }
-        : statusConfig[status];
+    // so users know why cells are disabled. If Spark init FAILED (bad library),
+    // show a red "Spark not ready" — the kernel is alive but unusable for Spark,
+    // so it must not read as a healthy green "Connected".
+    const config = status === 'connected' && sparkFailed
+        ? { color: 'text-rose-500', label: 'Spark not ready', icon: 'circle' as const }
+        : status === 'connected' && sparkInitializing
+            ? { color: 'text-amber-500 animate-pulse', label: 'Booting Spark...', icon: 'circle' as const }
+            : statusConfig[status];
     const tooltipText = status === 'dead' && deadReason ? `${config.label}: ${deadReason}` : config.label;
 
     return (

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -880,6 +880,11 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
     const restart = useCallback(async () => {
         const sess = sessionManager.getSession(notebookId);
         if (!sess.kernelId) return;
+        // A restart starts a FRESH kernel process (same kernel_id), so the
+        // "Spark already initialized for this kernel" marker is now void —
+        // clear it or NotebookPage's auto-init effect would skip re-running the
+        // init cell and the new libraries (or a clean restart) would never load.
+        try { localStorage.removeItem(`sparklabx_spark_inited_${notebookId}`); } catch { /* ignore */ }
         try {
             if (kernelProxyUrl) {
                 await axios.post(`${kernelProxyUrl}/api/kernels/${sess.kernelId}/restart`);
@@ -899,6 +904,30 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             });
             sess.pendingExecutions.forEach(p => p.resolve?.());
             sess.pendingExecutions.clear();
+
+            // Prompt the kernel to report idle so connectionStatus returns to
+            // 'connected'. Without this the post-restart iopub idle can be missed
+            // (it can arrive before we set 'starting', so the status handler's
+            // guard drops it) and the badge sticks on 'starting' until a reload —
+            // which also blocks NotebookPage's auto-init effect from re-running.
+            // Mirrors the connect path's shell kernel_info_request + fallback.
+            const promptIdle = () => {
+                const s = sessionManager.getSession(notebookId);
+                if (s.ws && s.ws.readyState === WebSocket.OPEN) {
+                    s.ws.send(JSON.stringify({
+                        header: { msg_id: crypto.randomUUID(), msg_type: 'kernel_info_request', username: 'user', session: crypto.randomUUID(), date: new Date().toISOString(), version: '5.3' },
+                        parent_header: {}, metadata: {}, content: {}, buffers: [], channel: 'shell',
+                    }));
+                }
+            };
+            setTimeout(promptIdle, 600);
+            setTimeout(promptIdle, 2500);
+            setTimeout(() => {
+                const s = sessionManager.getSession(notebookId);
+                if (s.status === 'starting') {
+                    sessionManager.updateSession(notebookId, { status: 'connected', podPhase: '', podMessage: '' });
+                }
+            }, 15000);
         } catch (e) {
             console.error(`[JupyterKernel][${notebookId}] restart failed`, e);
             throw e;


### PR DESCRIPTION
Promotes #90. Tag v0.2.0 moves to this commit.

Full library-load UX (#33): failure detection from kernel log + cell, single-owner reporting, no stuck badge, honest 'Spark not ready' state, no input layout jump.