### PR TITLE
chore(security): repo security scanning (CodeQL + Dependabot + npm audit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Go backend
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  # Frontend (npm)
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-deps:
+        patterns: ["*"]
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Container base images
+  - package-ecosystem: docker
+    directories:
+      - /backend
+      - /frontend
+      - /kernel
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
         continue-on-error: true
+      - name: golangci-lint (lint + gosec)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: backend
+          args: --timeout=5m
+        continue-on-error: true
 
   frontend:
     name: Frontend (Vite + TS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci --legacy-peer-deps
+      - name: npm audit (CVE scan)
+        run: npm audit --audit-level=high
+        continue-on-error: true
       - name: ESLint
         run: npx eslint src/
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+# Static analysis (SAST) for Go + the TS/JS frontend. Runs on every PR into the
+# protected branches (the only path branch protection allows), on a weekly
+# schedule to catch newly-published query rules, and on manual dispatch.
+on:
+  pull_request:
+    branches: [dev, test, main]
+  schedule:
+    - cron: '27 3 * * 1' # Mondays 03:27 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  # `standard` = errcheck, govet, ineffassign, staticcheck, unused.
+  default: standard
+  enable:
+    - gosec      # security: hardcoded creds, weak crypto, SQLi patterns, etc.
+    - bodyclose  # unclosed HTTP response bodies
+    - misspell
+    - unconvert


### PR DESCRIPTION
Sets up automated security scanning for the repo so contributors and users have assurance the codebase is continuously checked.

## What this adds
- **CodeQL SAST** (`.github/workflows/codeql.yml`) — static analysis for Go and the TS/JS frontend, on every PR into dev/test/main + weekly schedule (`security-and-quality` suite).
- **Dependabot version updates** (`.github/dependabot.yml`) — weekly grouped updates for gomod (backend), npm (frontend), github-actions, and docker base images (backend/frontend/kernel).
- **npm audit** CVE scan in the frontend CI job — mirrors the existing `govulncheck` Go CVE scan.
- **golangci-lint** (`.golangci.yml` + backend CI step) — standard linters + `gosec` (security), `bodyclose`, `misspell`, `unconvert`.

## Already enabled at the repo level (settings, not in this diff)
- Secret scanning + push protection
- Dependabot vulnerability alerts + security updates

## Notes
- New scans are non-blocking initially (`continue-on-error` for npm audit + golangci-lint, matching govulncheck) so they report without breaking builds; can be tightened later.
- No application code changed — `.github/` + `.golangci.yml` config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)