### PR TITLE
chore(release): bump chart to 0.3.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,7 +4,7 @@ description: Self-hosted Apache Spark notebooks with per-user isolation.
 type: application
 # Chart version (bump on chart changes). App version tracks the backend
 # image tag — keep in sync with the GitHub release.
-version: 0.2.0
+version: 0.3.0
 appVersion: "main"
 home: https://github.com/sparklabx/sparklabx
 sources:


### PR DESCRIPTION
Marks the v0.3.0 release (data connectors + SSO). appVersion stays "main" (images tagged :main/:latest by the release workflow).