### PR TITLE
chore(ci): CodeQL action v4 + analyze default branch on push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,12 @@
 name: CodeQL
 
 # Static analysis (SAST) for Go + the TS/JS frontend. Runs on every PR into the
-# protected branches (the only path branch protection allows), on a weekly
-# schedule to catch newly-published query rules, and on manual dispatch.
+# protected branches, on push to the default branch (so the Security tab shows
+# code-scanning alerts for main), on a weekly schedule to catch newly-published
+# query rules, and on manual dispatch.
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [dev, test, main]
   schedule:
@@ -34,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -42,9 +45,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
Fixes the CodeQL workflow warnings: bump codeql-action v3→v4 (deprecation + Node 20) and add on.push:[main] so the Security tab shows alerts for the default branch.