### PR TITLE
feat(connectors): add AWS Athena connector type

### DIFF
--- a/backend/internal/handlers/connectors.go
+++ b/backend/internal/handlers/connectors.go
@@ -61,6 +61,18 @@ var connectorTypes = map[string]ConnectorType{
 		MetaStrategy:  "jdbc-information-schema", DefaultAuth: "broker-mapped",
 		AuthOptions: []string{"broker-mapped"},
 	},
+	"athena": {
+		ID: "athena", Label: "AWS Athena", Icon: "athena",
+		DriverClass:   "com.amazon.athena.jdbc.AthenaDriver",
+		DriverPackage: "com.amazonaws:athena-jdbc:2025.15.1",
+		// No catalog browser: there's no Go Athena driver for the
+		// information_schema path, so the sidebar shows a query() hint.
+		MetaStrategy: "none", DefaultAuth: "broker-mapped",
+		// broker-mapped username/password → the Athena JDBC driver reads them
+		// as User=AccessKeyId / Password=SecretAccessKey. (IAM-role / DefaultChain
+		// auth — leave creds blank, put CredentialsProvider=DefaultChain in the URL.)
+		AuthOptions: []string{"broker-mapped"},
+	},
 	// bigquery / snowflake / … land here as each connector is added.
 }
 

--- a/frontend/src/components/Notebooks/AddConnectorDialog.tsx
+++ b/frontend/src/components/Notebooks/AddConnectorDialog.tsx
@@ -28,12 +28,19 @@ const URL_PLACEHOLDER: Record<string, string> = {
     trino: 'jdbc:trino://trino.corp:443?SSL=true',
     postgres: 'jdbc:postgresql://db.corp:5432/analytics',
     mysql: 'jdbc:mysql://db.corp:3306/analytics',
+    athena: 'jdbc:athena://Region=us-east-1;OutputLocation=s3://my-bucket/athena/;WorkGroup=primary',
 };
 
 const AUTH_LABEL: Record<string, string> = {
     'app-jwt': 'App-signed JWT (any login works)',
     'idp-passthrough': 'Forward IdP token (SSO only)',
     'broker-mapped': 'Username / password',
+};
+
+// Per-type credential field labels — Athena's broker-mapped creds are an AWS
+// access key, which the Athena JDBC driver reads as User / Password.
+const CRED_LABELS: Record<string, { user: string; pass: string }> = {
+    athena: { user: 'Access key ID', pass: 'Secret access key' },
 };
 
 // "Trino Staging" → "trino_staging" — the notebook helper id is derived from the
@@ -108,6 +115,10 @@ export const AddConnectorDialog: React.FC<{
     const [port, setPort] = useState('');
     const [database, setDatabase] = useState('');
     const [ssl, setSsl] = useState(false);
+    // Athena-specific structured fields (no host/port — it's an AWS API endpoint).
+    const [region, setRegion] = useState('');
+    const [s3out, setS3out] = useState('');
+    const [workgroup, setWorkgroup] = useState('');
     const [advanced, setAdvanced] = useState(false); // true → edit the raw JDBC URL
     const [auth, setAuth] = useState('');
     const [username, setUsername] = useState('');
@@ -124,6 +135,7 @@ export const AddConnectorDialog: React.FC<{
         // Reset on open.
         setLabel(''); setId(''); setUrl(''); setUsername(''); setPassword(''); setHasPassword(false); setTestResult(null);
         setHost(''); setPort(''); setDatabase(''); setSsl(false); setAdvanced(false);
+        setRegion(''); setS3out(''); setWorkgroup('');
         axios.get<{ types?: ConnectorTypeInfo[] }>('/api/v1/connector-types')
             .then(r => {
                 const ts = r.data?.types || [];
@@ -166,8 +178,13 @@ export const AddConnectorDialog: React.FC<{
     // switched to Advanced and is editing the raw URL directly).
     useEffect(() => {
         if (advanced) return;
+        if (typeId === 'athena') {
+            const r = region.trim(), s = s3out.trim(), w = workgroup.trim();
+            setUrl(r && s ? `jdbc:athena://Region=${r};OutputLocation=${s}` + (w ? `;WorkGroup=${w}` : '') : '');
+            return;
+        }
         setUrl(buildJdbcUrl(typeId, host, port, database, ssl));
-    }, [advanced, typeId, host, port, database, ssl]);
+    }, [advanced, typeId, host, port, database, ssl, region, s3out, workgroup]);
 
     const testConnection = async () => {
         if (!typeId || !url.trim()) { toast.error('Pick a type and enter a URL first'); return; }
@@ -219,7 +236,7 @@ export const AddConnectorDialog: React.FC<{
                     <DialogTitle className="flex items-center gap-2">
                         <Database className="size-4 text-muted-foreground" /> {editing ? 'Edit data source' : 'Add data source'}
                     </DialogTitle>
-                    <DialogDescription>Connect a Trino, PostgreSQL or MySQL source for notebooks.</DialogDescription>
+                    <DialogDescription>Connect a Trino, PostgreSQL, MySQL or AWS Athena source for notebooks.</DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-3 text-sm">
@@ -248,6 +265,33 @@ export const AddConnectorDialog: React.FC<{
                             </div>
                             <input className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm font-mono"
                                 placeholder={URL_PLACEHOLDER[typeId] || 'jdbc:…'} value={url} onChange={e => setUrl(e.target.value)} />
+                        </div>
+                    ) : typeId === 'athena' ? (
+                        <div className="space-y-2">
+                            <div className="grid grid-cols-2 gap-2">
+                                <div className="space-y-1.5">
+                                    <Label className="text-xs">AWS Region</Label>
+                                    <input className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm font-mono"
+                                        placeholder="us-east-1" value={region} onChange={e => setRegion(e.target.value.trim())} />
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label className="text-xs">Workgroup</Label>
+                                    <input className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+                                        placeholder="primary" value={workgroup} onChange={e => setWorkgroup(e.target.value)} />
+                                </div>
+                            </div>
+                            <div className="space-y-1.5">
+                                <Label className="text-xs">S3 results location</Label>
+                                <input className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm font-mono"
+                                    placeholder="s3://my-bucket/athena/" value={s3out} onChange={e => setS3out(e.target.value)} />
+                            </div>
+                            <div className="flex items-center justify-end">
+                                <button type="button" className="text-[11px] text-primary hover:underline"
+                                    onClick={() => setAdvanced(true)}>Advanced: JDBC URL</button>
+                            </div>
+                            {url && (
+                                <p className="text-[11px] text-muted-foreground font-mono break-all">{url}</p>
+                            )}
                         </div>
                     ) : (
                         <div className="space-y-2">
@@ -298,13 +342,13 @@ export const AddConnectorDialog: React.FC<{
                     {auth === 'broker-mapped' && (
                         <div className="grid grid-cols-2 gap-2">
                             <div className="space-y-1.5">
-                                <Label className="text-xs">Username</Label>
+                                <Label className="text-xs">{CRED_LABELS[typeId]?.user || 'Username'}</Label>
                                 <input className="flex h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
                                     value={username} onChange={e => setUsername(e.target.value)} />
                             </div>
                             <div className="space-y-1.5">
                                 <Label className="text-xs flex items-center gap-1.5">
-                                    Password
+                                    {CRED_LABELS[typeId]?.pass || 'Password'}
                                     {editing && (hasPassword
                                         ? <span className="text-[10px] font-normal text-emerald-600 dark:text-emerald-400">• set</span>
                                         : <span className="text-[10px] font-normal text-muted-foreground">• none</span>)}

--- a/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
+++ b/frontend/src/components/Notebooks/KernelConnectionDialog.tsx
@@ -124,6 +124,13 @@ const PACKAGE_PRESETS: PackagePreset[] = [
         packages: ['com.mysql:mysql-connector-j:9.1.0'],
         group: 'driver',
     },
+    {
+        id: 'athena',
+        label: 'AWS Athena',
+        description: 'Athena JDBC 3.x driver — for query() Athena data sources',
+        packages: ['com.amazonaws:athena-jdbc:2025.15.1'],
+        group: 'driver',
+    },
 ];
 
 const PRESET_GROUPS: { group: PackagePreset['group']; title: string }[] = [

--- a/frontend/src/components/Notebooks/SidebarConnectors.tsx
+++ b/frontend/src/components/Notebooks/SidebarConnectors.tsx
@@ -5,6 +5,7 @@ import { Database, ChevronRight, ChevronDown, Table2, Loader2, RefreshCw, Shield
 import { TrinoIcon } from './parts/TrinoIcon';
 import { PostgresIcon } from './parts/PostgresIcon';
 import { MysqlIcon } from './parts/MysqlIcon';
+import { AthenaIcon } from './parts/AthenaIcon';
 import { AddConnectorDialog } from './AddConnectorDialog';
 
 // Data-source manager. Lists the configured connectors (Trino, Postgres, …) and,
@@ -43,6 +44,7 @@ const ConnectorIcon: React.FC<{ kind: string }> = ({ kind }) => {
         kind === 'trino' ? <TrinoIcon className="h-3.5 w-auto" /> :
         kind === 'postgres' ? <PostgresIcon className="size-3.5" /> :
         kind === 'mysql' ? <MysqlIcon className="size-3.5" /> :
+        kind === 'athena' ? <AthenaIcon className="size-3.5" /> :
         <Database className="size-3.5" />;
     return <span className="inline-flex w-4 shrink-0 items-center justify-center">{glyph}</span>;
 };

--- a/frontend/src/components/Notebooks/parts/AthenaIcon.tsx
+++ b/frontend/src/components/Notebooks/parts/AthenaIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+// AWS Athena — drawn as Athena's owl (the goddess's emblem), a simple monochrome
+// line mark that inherits currentColor so it tints like the other connector
+// glyphs (muted, turns primary when active). Original mark, not the AWS logo.
+// ponytail: simple owl glyph; swap for official artwork if branding ever matters.
+export const AthenaIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"
+        strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+        <path d="M5.5 4 8 7M18.5 4 16 7" />
+        <path d="M12 21c-4.2 0-7-3.1-7-7.2C5 9.5 8 6.6 12 6.6s7 2.9 7 7.2C19 17.9 16.2 21 12 21Z" />
+        <circle cx="9" cy="12.2" r="1.6" />
+        <circle cx="15" cy="12.2" r="1.6" />
+        <path d="M11 15.4l1 1 1-1" />
+    </svg>
+);

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -29,6 +29,16 @@ RUN python3 -c "from pyspark.sql import SparkSession; SparkSession.builder.maste
  && coursier fetch "io.trino:trino-jdbc:${TRINO_JDBC_VERSION}" > /dev/null \
  && echo "pre-warmed Trino JDBC ${TRINO_JDBC_VERSION} (ivy + coursier)"
 
+# Pre-warm the AWS Athena JDBC 3.x driver (self-contained uber-jar on Maven
+# Central) the same way as Trino — warms Ivy + coursier caches so the first
+# query("athena", …) resolves offline instead of a slow Maven round-trip. Does
+# NOT bake the jar onto the classpath. Keep ATHENA_JDBC_VERSION in sync with the
+# "AWS Athena" preset (connectorTypes DriverPackage in backend connectors.go).
+ENV ATHENA_JDBC_VERSION=2025.15.1
+RUN python3 -c "from pyspark.sql import SparkSession; SparkSession.builder.master('local[1]').config('spark.jars.packages','com.amazonaws:athena-jdbc:${ATHENA_JDBC_VERSION}').getOrCreate().stop()" \
+ && coursier fetch "com.amazonaws:athena-jdbc:${ATHENA_JDBC_VERSION}" > /dev/null \
+ && echo "pre-warmed Athena JDBC ${ATHENA_JDBC_VERSION} (ivy + coursier)"
+
 # DataFlint (Spark performance UI) is ON BY DEFAULT for PySpark AND Scala —
 # pre-warm both resolver caches: Ivy (/root/.ivy2) for PySpark's
 # spark.jars.packages, coursier (/root/.cache/coursier) for Almond's $ivy — so


### PR DESCRIPTION
Adds **AWS Athena** as a new connector type, alongside Trino / PostgreSQL / MySQL. The connector framework is type-agnostic, so this is a small, contained addition.

## What's included
- **Backend** ([connectors.go](backend/internal/handlers/connectors.go)): one `connectorTypes` entry — Athena JDBC 3.x driver `com.amazon.athena.jdbc.AthenaDriver` (`com.amazonaws:athena-jdbc:2025.15.1`), `broker-mapped` auth, no catalog browser (shows the `query()` hint). The existing broker-mapped credential + kernel JDBC paths work unchanged.
- **Kernel** ([Dockerfile](kernel/Dockerfile)): pre-warm the Athena JDBC uber-jar (Ivy + coursier caches), like Trino, so the first query isn't a slow Maven resolve.
- **Frontend**: Athena-specific structured form (AWS Region / Workgroup / S3 results location → assembles `jdbc:athena://Region=…;OutputLocation=…;WorkGroup=…`), per-type credential labels (**Access key ID** / **Secret access key**), an `AthenaIcon`, a sidebar icon case, and an Athena driver preset in the Connect-Kernel dialog so the "Add driver" nudge loads the jar.

## Auth
- **Now**: static AWS keys via broker-mapped — the driver reads `User`=AccessKeyId, `Password`=SecretAccessKey (stored AES-GCM).
- **Later** (per the agreed plan): IAM-role / instance-profile via `CredentialsProvider=DefaultChain` (blank creds). Works today through the Advanced JDBC URL; a dedicated auth option is a follow-up.

## Verification
- `go build ./...` + `go vet ./...` clean.
- `tsc --noEmit` + ESLint clean on changed files.
- ⚠️ **Live end-to-end** (`query("athena", "SELECT …")`) needs a real AWS account + Athena workgroup to verify — not reachable from CI/local. Driver coords, class, URL params and credential mapping were verified against AWS docs.

Refs: [JDBC v3 getting started](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-getting-started.html), [IAM credentials](https://docs.aws.amazon.com/athena/latest/ug/jdbc-v3-driver-iam-credentials.html).