### PR TITLE
Fix CodeQL security alerts (SSRF, format strings, log injection, sanitization)

### DIFF
--- a/backend/internal/handlers/local_kernel.go
+++ b/backend/internal/handlers/local_kernel.go
@@ -912,6 +912,14 @@ func (h *LocalKernelHandler) userHasOtherKernels(userID string) bool {
 	return false
 }
 
+// validKernelID matches Jupyter kernel UUIDs (hex + hyphens); validKernelWSPath
+// matches a single safe WS path segment. Both guard the proxied WebSocket
+// target URL against request forgery via a crafted kernel id or path.
+var (
+	validKernelID     = regexp.MustCompile(`^[a-zA-Z0-9-]{1,64}$`)
+	validKernelWSPath = regexp.MustCompile(`^/[a-zA-Z0-9_-]+$`)
+)
+
 // WebSocket proxies WebSocket connections to the user's kernel gateway.
 // ANY /api/v1/notebooks/:id/kernel/ws/:kernelId/*path
 func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
@@ -920,6 +928,10 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 		return
 	}
 	kernelID := c.Param("kernelId")
+	if !validKernelID.MatchString(kernelID) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid kernel id"})
+		return
+	}
 
 	// Update lastUsed for idle timeout tracking
 	userID := userIDString(c)
@@ -944,8 +956,14 @@ func (h *LocalKernelHandler) WebSocket(c *gin.Context) {
 	wsURL = strings.Replace(wsURL, "https://", "wss://", 1)
 
 	jupyterPath := c.Param("path")
-	if jupyterPath == "" {
+	if jupyterPath == "" || jupyterPath == "/" {
 		jupyterPath = "/channels"
+	}
+	// Restrict to a single safe path segment so a crafted *path can't redirect
+	// the proxied WebSocket to another host/endpoint (request forgery).
+	if !validKernelWSPath.MatchString(jupyterPath) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid kernel path"})
+		return
 	}
 	targetURL := fmt.Sprintf("%s/api/kernels/%s%s", wsURL, kernelID, jupyterPath)
 

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -175,7 +175,11 @@ const sessionManager = new KernelSessionManager();
 // kernelProxyUrl: optional, e.g. "/api/v1/kernel/{sessionId}/{token}"
 // When provided, connects directly to Jupyter Kernel Gateway via proxy
 // instead of using the standard /api/v1/notebooks/{id}/kernel/* endpoints
-export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
+export function useJupyterKernel(rawNotebookId: string, kernelProxyUrl?: string) {
+    // Sanitize once: notebook IDs are UUIDs ([\w-]), so stripping anything else
+    // is a no-op for valid ids while neutralizing format-string / log-injection
+    // in the many console logs below (and in URLs built from this id).
+    const notebookId = (rawNotebookId ?? '').replace(/[^\w-]/g, '');
     const [, forceUpdate] = useState({});
     const pageHiddenRef = useRef(typeof document !== 'undefined' ? document.hidden : false);
     const lastHiddenAtRef = useRef(0);
@@ -206,8 +210,9 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
             sessionManager.updateSession(notebookId, { podPhase: phase, podMessage: message });
 
             // Resume polling until the in-flight transition completes — stop on
-            // 'ready', 'failed', or (row gone after seeing a non-empty phase).
-            let sawNonEmpty = true; // initial phase was non-empty by the guard above
+            // 'ready', 'failed', or (row gone, i.e. phase empty — the initial
+            // phase was non-empty by the guard above, so an empty phase here
+            // means the spawn-status row disappeared).
             const deadline = Date.now() + 5 * 60 * 1000;
             while (!cancelled && Date.now() < deadline) {
                 await new Promise(r => setTimeout(r, 1500));
@@ -217,10 +222,9 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 phase = tick.data?.phase || '';
                 message = tick.data?.message || '';
                 sessionManager.updateSession(notebookId, { podPhase: phase, podMessage: message });
-                if (phase) sawNonEmpty = true;
                 if (phase === 'failed') return;
                 if (phase === 'ready') return;
-                if (phase === '' && sawNonEmpty) return;
+                if (phase === '') return;
             }
         })();
         return () => { cancelled = true; };
@@ -709,7 +713,7 @@ export function useJupyterKernel(notebookId: string, kernelProxyUrl?: string) {
                 // devLog(`[JupyterKernel][${notebookId}] 📨 Parsed message type:`, msg.header?.msg_type || msg.msg_type);
                 handleKernelMessage(msg);
             } catch (e) {
-                console.error(`[JupyterKernel][${notebookId}] ❌ Failed to parse message:`, e, event.data?.substring(0, 500));
+                console.error(`[JupyterKernel][${notebookId}] ❌ Failed to parse message:`, e, String(event.data ?? '').substring(0, 500).replace(/[\r\n]+/g, ' '));
             }
         };
 

--- a/frontend/src/hooks/useJupyterKernel.ts
+++ b/frontend/src/hooks/useJupyterKernel.ts
@@ -713,7 +713,12 @@ export function useJupyterKernel(rawNotebookId: string, kernelProxyUrl?: string)
                 // devLog(`[JupyterKernel][${notebookId}] 📨 Parsed message type:`, msg.header?.msg_type || msg.msg_type);
                 handleKernelMessage(msg);
             } catch (e) {
-                console.error(`[JupyterKernel][${notebookId}] ❌ Failed to parse message:`, e, String(event.data ?? '').substring(0, 500).replace(/[\r\n]+/g, ' '));
+                // Constant format string (no interpolation) + CR/LF-stripped
+                // dynamic args, so neither the kernel payload nor the parse
+                // error can inject a format directive or forge a log line.
+                console.error('[JupyterKernel][%s] Failed to parse message:', notebookId,
+                    String(e).replace(/[\r\n]+/g, ' '),
+                    String(event.data ?? '').substring(0, 500).replace(/[\r\n]+/g, ' '));
             }
         };
 

--- a/frontend/src/hooks/useKernelHoverProvider.ts
+++ b/frontend/src/hooks/useKernelHoverProvider.ts
@@ -36,11 +36,15 @@ export function useKernelHoverProvider(
             } else if (data['text/plain']?.trim()) {
                 body = '```text\n' + stripAnsi(data['text/plain']).trim() + '\n```';
             } else if (data['text/html']?.trim()) {
-                const stripped = data['text/html']
+                // Keep block breaks, then let the DOM strip every tag — a single
+                // tag-stripping regex is incomplete (e.g. "<scr<script>ipt>") and
+                // can leave executable markup behind.
+                const withBreaks = data['text/html']
                     .replace(/<br\s*\/?>/gi, '\n')
-                    .replace(/<p>/gi, '\n')
-                    .replace(/<[^>]+>/g, '')
-                    .trim();
+                    .replace(/<\/?p>/gi, '\n');
+                const stripped = (new DOMParser()
+                    .parseFromString(withBreaks, 'text/html')
+                    .body.textContent || '').trim();
                 if (stripped) body = '```text\n' + stripAnsi(stripped) + '\n```';
             }
             if (!body) return null;


### PR DESCRIPTION
Addresses the open CodeQL code-scanning alerts.

## Fixed in code (16 alerts)

**Critical — request forgery (#22, #23)**
`local_kernel.go` WebSocket proxy: validate the kernel id (`^[a-zA-Z0-9-]{1,64}$`) and restrict the `*path` to a single safe segment before building the gateway WS URL. The kernel id was already checked against the per-user kernel map; this adds a format barrier and blocks a crafted path from redirecting the proxied socket. `kernel_recorder.go` reuses the same target URL, so its dial is covered too.

**High — tainted format string (#9–#19, 11 alerts)**
`useJupyterKernel.ts`: sanitize `notebookId` once at the hook boundary (`replace(/[^\\w-]/g, '')`). Notebook ids are UUIDs, so this is a no-op for valid input while neutralizing format-string/log-injection payloads across the many `console.*` calls and URLs built from the id.

**High — incomplete multi-character sanitization (#6)**
`useKernelHoverProvider.ts`: strip HTML via `DOMParser().textContent` instead of a single tag-stripping regex (which leaves markup on inputs like `<scr<script>ipt>`).

**Medium — log injection (#21)** strip CR/LF from logged raw WS payloads.
**Warning — trivial conditional (#8)** drop an always-true polling guard.

## Recommend dismissing (3 alerts — false-positive / by-design)

- **#24 weak hashing (`minio_iam.go`)** — this derives an AES key from the high-entropy JWT secret, not a password. Switching the KDF would change the key and make all already-encrypted secrets (connector passwords, OIDC tokens, SSH keys) undecryptable. Recommend dismiss as false-positive.
- **#7 empty password (`chart/values.yaml`)** — intentional `REQUIRED` placeholder; meant to be set at install. Recommend dismiss (won't fix).
- **#20 log injection (`index.tsx`)** — a pass-through wrapper around `console.error` (browser devtools, not a server log). Recommend dismiss.

Verified locally: `go build`/`go vet` and frontend `tsc --noEmit` pass.